### PR TITLE
Update contribution, licensing and coypright guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,43 @@
 # Contributing OpenELA Documentation
 
 We welcome your contributions! There are multiple ways to contribute.
-All contributions to this repository and to OpenELA should following
-Contribution Guide including our Code of Conduct, which are included
-by reference here:
-https://github.com/openela/governance/blob/main/contributors_guidelines.md
 
-## Did you find a bug?
+All contributions to this repository and to OpenELA in general follow
+[the OpenELA Code of Conduct](https://github.com/openela/governance/blob/main/code_of_conduct.md).
 
-For bugs or enhancement requests, please open a GitHub issue. 
-The better written the bug is, the more likely it is to be fixed. 
+
+## Did you find an issue?
+
+For any issues, be it a defect, a missing documentation part or any enhancement
+request, please [open an issue on GitHub](https://github.com/openela/openela-documentation/issues).
+Please provide as much detail as you can provide, including a reference to the
+particular chapter or paragraph that the issue is referring to.
+
+The better written the issue is, the more likely it is going to get fixed.
+
 
 ## Contribute documentation
 
-This is a community project and we welcome community members to contribute 
-documentation to the project.
+This is a community project and we welcome community members to contribute
+documentation to the project. Contributions are done [by opening a pull request against the project](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
-Documentation contributions should be submitted as github pull requests, 
-must have a Developer Certificate of Origin (Signed-off-By tag), 
-and must be contributed under the [project license](./LICENSE).
+Any contribution requires a [Developer Certificate of Origin](https://developercertificate.org/) (a Signed-off-By tag in the commit message) and must adhere to the [project license](./LICENSE).
 
-Note that contributions should apply generally to Enterprise Linux. If your
-contribution is specific to a customization for a downstream distribution, the
-pull request might be denied.
+When you contribute, please submit your pull request against the `main` branch. Please include a summary of your changes in the Pull request initial comment as well as a link to, when available, any GitHub issues that this pull request is addressing.
 
-See the Contributors Guide for more information https://github.com/openela/governance/blob/main/contributors_guidelines.md
+Make sure that all validation Git Hub actions that are getting automatically executed when you open the Pull Request are passing. When they are not passing your PR might not be getting any timely reviews.
+
+Please do the Pull request per group / theme of change. You can use individual commits in the Pull Request to structure the changes in the form of smaller work items.
+
+The project maintainers will review your pull request. A positive (approving) review is required prior inclusion of the change into the project.
+
+If you have any questions, please reach out to the #documentation channel on the OpenELA slack.
+
+For major contributions, please add your Copyright information into the the main project README. For more targetted contributions, a Copyright statement can be included at the top of the respective file(s).
+
+Please note that contributions should apply generally to Enterprise Linux. If your contribution is specific to a customization for a downstream distribution, the pull request might not be considered for inclusion.
+
 
 ## Becoming a Documentation Maintainer
 
-As you contribute more and more, you earn the trust of the project maintainers
-and may even be invited to become a maintainer for the documentation project
-as well!
-
+Regularly active contributors earn the trust of the project maintainers and may even be invited to become a maintainer for the documentation project.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
+
 # openela-documentation
 
 ## Description
@@ -9,13 +11,31 @@ While we recognize that the size of these directories might grow over time and f
 For more information about this project see the #documentation channel on the OpenELA Slack.
 
 ## Contributing
-Contributions are welcome. Please fork and submit a pull request for any changes. 
+
+This project is open for contributions and Contributions are very welcome.
+When you're interested in contributing, please follow the [Contribution guidelines for this project](CONTRIBUTING.md).
+
 
 ## License
-Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-This work is licensed under a
-[Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
+<!-- Please update the list of major contributor to the project copyrights below -->
+Copyright © 2023, Oracle and/or its affiliates.
+
+
+This work and all files in this repository are licensed under [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa]. Each individual file can have additional Copyright
+notices in source. They are at the top of the files in [SPDX Reuse Format](https://reuse.software/spec/), for example like below:
+
+```
+<!--
+SPDX-FileCopyrightText: 2023 Jane Doe <jane@example.com>
+SPDX-FileCopyrightText: 2022 Example Company
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+```
+
+If you're contributing regularly to the documentation, please add your Copyright information in this file.
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ For more information about this project see the #documentation channel on the Op
 
 ## Contributing
 
-This project is open for contributions and Contributions are very welcome.
-When you're interested in contributing, please follow the [Contribution guidelines for this project](CONTRIBUTING.md).
+This project is open for contributions and contributions are very welcome.
+For contributions, please follow the [Contribution guidelines for this project](CONTRIBUTING.md).
 
 
 ## License


### PR DESCRIPTION
Suggest to keep main copyrights in the top level README.md, with the option to have file level copyrights where sections are selectively maintained and contributed to.

Clarify Code of Conduct and contribution references.