### PR TITLE
Update copyright to use SPDX comments

### DIFF
--- a/openela8/README.md
+++ b/openela8/README.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # OpenELA 8
 
 -   Managing Core System Configuration
@@ -428,7 +432,7 @@
                     -   [Create a CA Root Configuration File](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-root-conf)
                     -   [Create and Verify the CA Root Key Pair](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-root-keys)
                 -   [Create an intermediary CA](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary)
-                    -   [Create A CA Directory Structure](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#unique_969661122)
+                    -   [Create A CA Directory Structure](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#unique_44595629)
                     -   [Create the intermediary CA Configuration](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary-conf)
                     -   [Create a CSR for the intermediary CA](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary-csr)
                     -   [Create a signed certificate for the intermediary CA](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary-sign)
@@ -606,8 +610,4 @@
             -   [Creating a Host to Host Connection](topics/vpn-ConfiguringaVPNbyUsingLibreswan.md#vpn-host2host)
             -   [Creating a Site to Site Connection](topics/vpn-ConfiguringaVPNbyUsingLibreswan.md#vpn-site2site)
         -   [Verifying the Status of VPN Services](topics/vpn-ConfiguringaVPNbyUsingLibreswan.md#verify-libreswan)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/DNFCommandRef.md
+++ b/openela8/topics/DNFCommandRef.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # DNF Command References
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/accessibility-CustomizingAccessibilityFeatures.md
+++ b/openela8/topics/accessibility-CustomizingAccessibilityFeatures.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Customizing Accessibility Features
 
 ## Configuring the Screen Reader
@@ -7,8 +11,4 @@
 ## Configuring Typing Assist
 
 ## Configuring Click Assist
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/accessibility-OverviewofAccessibilityFeatures.md
+++ b/openela8/topics/accessibility-OverviewofAccessibilityFeatures.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Overview of Accessibility Features
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/accessibility-UsingBraille.md
+++ b/openela8/topics/accessibility-UsingBraille.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using Braille
 
 ## Configuring Braille Options on the Screen Reader
 
 ## Configuring the BRLTTY Service
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/accessibility-WorkingWithAccessibilityFeaturesinEnterpriseLinux.md
+++ b/openela8/topics/accessibility-WorkingWithAccessibilityFeaturesinEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working With Accessibility Features in Enterprise Linux 8
 
 ## Selecting a Desktop Version
@@ -11,8 +15,4 @@
 ### Using the Classic Desktop
 
 ### Configuring Quick Access
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/add_and_enable_a_firewall_service.md
+++ b/openela8/topics/add_and_enable_a_firewall_service.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Control Access to Zone Services
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/backup-about-backup.md
+++ b/openela8/topics/backup-about-backup.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Backup and Disaster Recovery
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/backup-ol-backup-rear-about.md
+++ b/openela8/topics/backup-ol-backup-rear-about.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Backups With ReaR
 
 ## Installing ReaR
@@ -21,8 +25,4 @@
 ## Recovering a System With ReaR
 
 ## Creating Multiple Backups With ReaR
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/backup-snapshots-data-mirroring.md
+++ b/openela8/topics/backup-snapshots-data-mirroring.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Backups With File System Snapshots and Data Mirroring
 
 ## Working With File System Snapshots
@@ -9,8 +13,4 @@
 ### Managing Geo-Replicated Data With Gluster Storage for Enterprise Linux
 
 ### Managing Block Device Redundancy With Software RAID
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/balancing-AboutLoadBalancinginEnterpriseLinux.md
+++ b/openela8/topics/balancing-AboutLoadBalancinginEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Load Balancing in Enterprise Linux
 
 ## About Load Balancing
@@ -11,8 +15,4 @@
 ## About Combining Keepalived With HAProxy for High-Availability Load Balancing
 
 ## About NGINX
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/balancing-SettingUpLoadBalancingbyUsingHAProxy.md
+++ b/openela8/topics/balancing-SettingUpLoadBalancingbyUsingHAProxy.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up Load Balancing by Using HAProxy
 
 ## Installing and Configuring HAProxy
@@ -9,8 +13,4 @@
 ## Using Weighted Round Robin Load Balancing with HAProxy
 
 ## Adding Session Persistence for HAProxy
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/balancing-SettingUpLoadBalancingbyUsingKeepalived.md
+++ b/openela8/topics/balancing-SettingUpLoadBalancingbyUsingKeepalived.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up Load Balancing by Using Keepalived
 
 ## Installing and Configuring Keepalived
@@ -11,8 +15,4 @@
 ### Configuring Backend Server Routing for Keepalived NAT-Mode Load Balancing
 
 ## Enhancing Load Balancing by Using Keepalived With HAProxy
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/balancing-SettingUpLoadBalancingbyUsingNGINX.md
+++ b/openela8/topics/balancing-SettingUpLoadBalancingbyUsingNGINX.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up Load Balancing by Using NGINX
 
 ## Installing NGINX
@@ -11,8 +15,4 @@
 ## Using Least-Connected Load Balancing With NGINX
 
 ## Adding Session Persistence for NGINX
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/banner_creation_dita.md
+++ b/openela8/topics/banner_creation_dita.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Cockpit Login Banner
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/certmanage-AboutPublicKeyInfrastructure.md
+++ b/openela8/topics/certmanage-AboutPublicKeyInfrastructure.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Public Key Infrastructure
 
 ## What is Public Key Cryptography?
 
 ## Automatic Certificate Management Environment \(ACME\)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/certmanage-UsingOpenSSLinEnterpriseLinux.md
+++ b/openela8/topics/certmanage-UsingOpenSSLinEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up TLS/SSL with OpenSSL
 
 ## Creating Key Pairs
@@ -57,8 +61,4 @@
 ## Using OpenSSL for File Encryption and Validation
 
 ## More information About OpenSSL
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/certmanage-other-tools.md
+++ b/openela8/topics/certmanage-other-tools.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up TLS/SSL with Other Tools
 
 ## GnuTLS
@@ -5,8 +9,4 @@
 ## NSS
 
 ## Java
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-config_host_tasks.md
+++ b/openela8/topics/cockpit-config_host_tasks.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # General Host Configuration Actions
 
 -   **[Change System Hostname](../topics/set_host_name.md)**  
@@ -12,8 +16,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-hosts_add_secondary_host.md
+++ b/openela8/topics/cockpit-hosts_add_secondary_host.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add and Connect to Secondary Host
 
 **Parent topic:**[Management of Multiple Hosts](../topics/cockpit-manage_multiple_hosts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-hosts_remove_secondary_host.md
+++ b/openela8/topics/cockpit-hosts_remove_secondary_host.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Edit or Remove Secondary Host
 
 **Parent topic:**[Management of Multiple Hosts](../topics/cockpit-manage_multiple_hosts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-install.md
+++ b/openela8/topics/cockpit-install.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Get Started: Cockpit Web Console
 
 -   **[Cockpit Web Console Overview](../topics/cockpit_overview.md)**  
@@ -12,8 +16,4 @@
 
 -   **[Extend Cockpit's Functionality](../topics/extend_cockpit.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-install_install_the_cockpit_package.md
+++ b/openela8/topics/cockpit-install_install_the_cockpit_package.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Enable Cockpit
 
 **Parent topic:**[Installation and Log In](../topics/cockpit-install_section.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-install_logging_into_cockpit.md
+++ b/openela8/topics/cockpit-install_logging_into_cockpit.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Log in to the Cockpit Web Console
 
 **Parent topic:**[Installation and Log In](../topics/cockpit-install_section.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-install_section.md
+++ b/openela8/topics/cockpit-install_section.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Installation and Log In
 
 -   **[Install and Enable Cockpit](../topics/cockpit-install_install_the_cockpit_package.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kdump.md
+++ b/openela8/topics/cockpit-kdump.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Capture Crash Dump Details Using Kdump
 
 -   **[Overview of Crash Recovery in Kdump](../topics/cockpit-kdump_access_the_kernel_dump_information.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Debugging Tools](../topics/manage_host_debugging_tools.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kdump_access_the_kernel_dump_information.md
+++ b/openela8/topics/cockpit-kdump_access_the_kernel_dump_information.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Overview of Crash Recovery in Kdump
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kdump_enable_kdump_configure_memory_and_specify_the_crash_dump_location.md
+++ b/openela8/topics/cockpit-kdump_enable_kdump_configure_memory_and_specify_the_crash_dump_location.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Crash Dump Target Location
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kdump_modify_kdump_service_at_boot.md
+++ b/openela8/topics/cockpit-kdump_modify_kdump_service_at_boot.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Kdump Service State
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kdump_test_your_kdump_settings.md
+++ b/openela8/topics/cockpit-kdump_test_your_kdump_settings.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Test the Kdump Configuration
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm.md
+++ b/openela8/topics/cockpit-kvm.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Virtual Machine \(VM\) Management Tasks
 
 -   **[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)**  
@@ -16,8 +20,4 @@
 
 -   **[Share a Host Directory with VM Instance](../topics/cockpit-kvm_mountshared_directory.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_attach_host.md
+++ b/openela8/topics/cockpit-kvm_attach_host.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Attach or Remove VM Host Devices
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_check_the_storage_pools.md
+++ b/openela8/topics/cockpit-kvm_check_the_storage_pools.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Storage Pool
 
 **Parent topic:**[Manage Storage Pools for VM Instances](../topics/cockpit-kvm_manage_storage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_clone_vm.md
+++ b/openela8/topics/cockpit-kvm_clone_vm.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Clone an Existing VM Instance
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_console.md
+++ b/openela8/topics/cockpit-kvm_console.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Console for VM Interaction
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_cpu_mem_autostart.md
+++ b/openela8/topics/cockpit-kvm_cpu_mem_autostart.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Edit Memory, CPU, Autostart, or Watchdog Properties
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_create_a_virtual_machine.md
+++ b/openela8/topics/cockpit-kvm_create_a_virtual_machine.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a VM Instance
 
 -   **[Install Cockpit-Machines and Enable Virtualization](../topics/cockpit-kvm_install_the_cockpit_virtual_machines_module.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_delete_storage_pool.md
+++ b/openela8/topics/cockpit-kvm_delete_storage_pool.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Existing Storage Pools
 
 **Parent topic:**[Manage Storage Pools for VM Instances](../topics/cockpit-kvm_manage_storage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_disk.md
+++ b/openela8/topics/cockpit-kvm_disk.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add, Edit, or Remove Disks
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_import_vm.md
+++ b/openela8/topics/cockpit-kvm_import_vm.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Import a VM From a Disk Image
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_install_the_cockpit_virtual_machines_module.md
+++ b/openela8/topics/cockpit-kvm_install_the_cockpit_virtual_machines_module.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install Cockpit-Machines and Enable Virtualization
 
 **Parent topic:**[Create a VM Instance](../topics/cockpit-kvm_create_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_manage_instance.md
+++ b/openela8/topics/cockpit-kvm_manage_instance.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure VM Devices and Services
 
 -   **[Edit Memory, CPU, Autostart, or Watchdog Properties](../topics/cockpit-kvm_cpu_mem_autostart.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_manage_storage.md
+++ b/openela8/topics/cockpit-kvm_manage_storage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Storage Pools for VM Instances
 
 -   **[Create a Storage Pool](../topics/cockpit-kvm_check_the_storage_pools.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_migrate_virtual_machine.md
+++ b/openela8/topics/cockpit-kvm_migrate_virtual_machine.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Requirements to Migrate Virtual Machine
 
 **Parent topic:**[Migrate a Running VM to Another KVM Host](../topics/cockpit-kvm_migrate_vm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_migrate_vm.md
+++ b/openela8/topics/cockpit-kvm_migrate_vm.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Migrate a Running VM to Another KVM Host
 
 -   **[Requirements to Migrate Virtual Machine](../topics/cockpit-kvm_migrate_virtual_machine.md)**  
 
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_mountshared_directory.md
+++ b/openela8/topics/cockpit-kvm_mountshared_directory.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Share a Host Directory with VM Instance
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_network_interface.md
+++ b/openela8/topics/cockpit-kvm_network_interface.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add, Edit, Unplug, or Plug VM Network Interface
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_reboot_shutdown.md
+++ b/openela8/topics/cockpit-kvm_reboot_shutdown.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Start, Shutdown, Remove, or Interrupt a VM Instance
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_snapshot.md
+++ b/openela8/topics/cockpit-kvm_snapshot.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create, Delete, or Revert a Snapshot of VM Instance
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-kvm_video_demonstration.md
+++ b/openela8/topics/cockpit-kvm_video_demonstration.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Video Demonstration
 
 **Parent topic:**[Create a VM Instance](../topics/cockpit-kvm_create_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-luks.md
+++ b/openela8/topics/cockpit-luks.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Encrypt Block Devices With LUKS
 
 -   **[Lock Disk Device With LUKs](../topics/cockpit-luks_lock_data_on_a_device_with_luks.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-luks_change_the_luks_configuration.md
+++ b/openela8/topics/cockpit-luks_change_the_luks_configuration.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Passphrase Key for LUKS Encryption
 
 **Parent topic:**[Encrypt Block Devices With LUKS](../topics/cockpit-luks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-luks_lock_data_on_a_device_with_luks.md
+++ b/openela8/topics/cockpit-luks_lock_data_on_a_device_with_luks.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Lock Disk Device With LUKs
 
 **Parent topic:**[Encrypt Block Devices With LUKS](../topics/cockpit-luks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm.md
+++ b/openela8/topics/cockpit-lvm.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Logical Volumes With LVM
 
 -   **[Create a Volume Group](../topics/cockpit-lvm_create_volume_groups.md)**  
@@ -14,8 +18,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_create_logical_volumes.md
+++ b/openela8/topics/cockpit-lvm_create_logical_volumes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Logical Volume
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_create_volume_groups.md
+++ b/openela8/topics/cockpit-lvm_create_volume_groups.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Volume Group
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_format_logical_volumes.md
+++ b/openela8/topics/cockpit-lvm_format_logical_volumes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Format and Mount a Logical Volume
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_overview.md
+++ b/openela8/topics/cockpit-lvm_overview.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Rename a Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_remove_logical_volume.md
+++ b/openela8/topics/cockpit-lvm_remove_logical_volume.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Logical Volume From Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_remove_vol_groupdita.md
+++ b/openela8/topics/cockpit-lvm_remove_vol_groupdita.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_resize_logical_volumes.md
+++ b/openela8/topics/cockpit-lvm_resize_logical_volumes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Resize Logical Volumes
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-lvm_thin-logical-volume.md
+++ b/openela8/topics/cockpit-lvm_thin-logical-volume.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Thin Logical Volume
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-manage_multiple_hosts.md
+++ b/openela8/topics/cockpit-manage_multiple_hosts.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Management of Multiple Hosts
 
 -   **[Security Considerations for Multiple Host Management](../topics/cockpit_host_security_considerations.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-monitor.md
+++ b/openela8/topics/cockpit-monitor.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # System Monitoring Actions
 
 -   **[Health, Usage, and System Details](../topics/view_system.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-monitor_using_available_quantifiers.md
+++ b/openela8/topics/cockpit-monitor_using_available_quantifiers.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Filter Log Entries
 
 **Parent topic:**[System Monitoring Actions](../topics/cockpit-monitor.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-nbde.md
+++ b/openela8/topics/cockpit-nbde.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Unlock Encrypted Devices Using Tang Server Key
 
 -   **[Create a Tang Key for Encrypted Device](../topics/cockpit-nbde_create_a_tang_key_for_the_encrypted_device.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-nbde_confirm_that_the_configuration_is_successful.md
+++ b/openela8/topics/cockpit-nbde_confirm_that_the_configuration_is_successful.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Confirm Tang Key Implementation on Encrypted Device
 
 **Parent topic:**[Unlock Encrypted Devices Using Tang Server Key](../topics/cockpit-nbde.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-nbde_create_a_tang_key_for_the_encrypted_device.md
+++ b/openela8/topics/cockpit-nbde_create_a_tang_key_for_the_encrypted_device.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Tang Key for Encrypted Device
 
 **Parent topic:**[Unlock Encrypted Devices Using Tang Server Key](../topics/cockpit-nbde.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-networ_view_firewall_log_files.md
+++ b/openela8/topics/cockpit-networ_view_firewall_log_files.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View Network Host Log Files
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network.md
+++ b/openela8/topics/cockpit-network.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Network Management Tasks
 
 -   **[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)**  
@@ -14,8 +18,4 @@
 
 -   **[View Network Host Log Files](../topics/cockpit-networ_view_firewall_log_files.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_access_zone_information.md
+++ b/openela8/topics/cockpit-network_access_zone_information.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Display Firewall Zone Properties
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_add_a_pre_defined_zone.md
+++ b/openela8/topics/cockpit-network_add_a_pre_defined_zone.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add a New Predefined Zone
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_configure_a_network_bond.md
+++ b/openela8/topics/cockpit-network_configure_a_network_bond.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network Bonding Properties
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_configure_a_network_team.md
+++ b/openela8/topics/cockpit-network_configure_a_network_team.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network Teaming Properties
 
 -   **[Teaming and Bonding Feature Comparison](../topics/cockpit-network_team_and_bond_feature_comparison.md)**  
 
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_configure_the_firewall.md
+++ b/openela8/topics/cockpit-network_configure_the_firewall.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Firewall Zoning Properties
 
 -   **[Change Host Firewall State](../topics/cockpit-network_enable_disable_firewalld_service.md)**  
@@ -12,8 +16,4 @@
 
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_control_access_to_interface.md
+++ b/openela8/topics/cockpit-network_control_access_to_interface.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Monitor or Change Interface Connections
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_enable_disable_firewalld_service.md
+++ b/openela8/topics/cockpit-network_enable_disable_firewalld_service.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Host Firewall State
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_remove_or_modify_zone.md
+++ b/openela8/topics/cockpit-network_remove_or_modify_zone.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove an Existing Predefined Zone
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-network_team_and_bond_feature_comparison.md
+++ b/openela8/topics/cockpit-network_team_and_bond_feature_comparison.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Teaming and Bonding Feature Comparison
 
 **Parent topic:**[Configure Network Teaming Properties](../topics/cockpit-network_configure_a_network_team.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-nfsmounts.md
+++ b/openela8/topics/cockpit-nfsmounts.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage NFS Mounted Connections
 
 -   **[Add NFS Server Connections](../topics/cockpit-nfsmounts_connect_nfs_mounts.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-nfsmounts_connect_nfs_mounts.md
+++ b/openela8/topics/cockpit-nfsmounts_connect_nfs_mounts.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add NFS Server Connections
 
 **Parent topic:**[Manage NFS Mounted Connections](../topics/cockpit-nfsmounts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-nfsmounts_customize_mount_options.md
+++ b/openela8/topics/cockpit-nfsmounts_customize_mount_options.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change NFS Server Connections
 
 **Parent topic:**[Manage NFS Mounted Connections](../topics/cockpit-nfsmounts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-partition.md
+++ b/openela8/topics/cockpit-partition.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Disk Devices and Partitions
 
 -   **[Create Physical Disk Partitions](../topics/cockpit-partition_create_partitions.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-partition_considerations.md
+++ b/openela8/topics/cockpit-partition_considerations.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Storage Partitioning Considerations and Prerequisites
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-partition_create_partitions.md
+++ b/openela8/topics/cockpit-partition_create_partitions.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create Physical Disk Partitions
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-partition_display_partitions_that_are_formatted_with_file_systems.md
+++ b/openela8/topics/cockpit-partition_display_partitions_that_are_formatted_with_file_systems.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Change Drive Partition Properties
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-podman.md
+++ b/openela8/topics/cockpit-podman.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Management Tasks
 
 -   **[Install and Configure Cockpit-Podman](../topics/cockpit-podman_enable_podman_service.md)**  
@@ -8,8 +12,4 @@
 
 -   **[Podman Pod Management](../topics/podman_pod_management.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-podman_enable_podman_service.md
+++ b/openela8/topics/cockpit-podman_enable_podman_service.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Configure Cockpit-Podman
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-podman_managing_podman_containers.md
+++ b/openela8/topics/cockpit-podman_managing_podman_containers.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Container Management
 
 -   **[Create and Run Container](../topics/podman_container_mgmt.md)**  
@@ -16,8 +20,4 @@
 
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-podman_managing_podman_images.md
+++ b/openela8/topics/cockpit-podman_managing_podman_images.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Image Management
 
 -   **[Search and Download New Images](../topics/podman_image_download.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-raid.md
+++ b/openela8/topics/cockpit-raid.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Build and Manage Software RAID Devices
 
 -   **[Create and Configure a New Storage Array](../topics/cockpit-raid_create_raid_storage.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-raid_create_raid_storage.md
+++ b/openela8/topics/cockpit-raid_create_raid_storage.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create and Configure a New Storage Array
 
 **Parent topic:**[Build and Manage Software RAID Devices](../topics/cockpit-raid.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-raid_format_raid_storage.md
+++ b/openela8/topics/cockpit-raid_format_raid_storage.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Software RAID Levels
 
 **Parent topic:**[Build and Manage Software RAID Devices](../topics/cockpit-raid.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-selinux_manage.md
+++ b/openela8/topics/cockpit-selinux_manage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage SELinux Security Policy and Messages
 
 -   **[Change SELinux Policy Mode](../topics/cockpit-selinux_manage_policy_mode.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-selinux_manage_logs.md
+++ b/openela8/topics/cockpit-selinux_manage_logs.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage SELinux Alert Message
 
 **Parent topic:**[Manage SELinux Security Policy and Messages](../topics/cockpit-selinux_manage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-selinux_manage_policy_mode.md
+++ b/openela8/topics/cockpit-selinux_manage_policy_mode.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change SELinux Policy Mode
 
 **Parent topic:**[Manage SELinux Security Policy and Messages](../topics/cockpit-selinux_manage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-selinux_manage_script.md
+++ b/openela8/topics/cockpit-selinux_manage_script.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View SELinx Modifications and Copy Automation Script
 
 **Parent topic:**[Manage SELinux Security Policy and Messages](../topics/cockpit-selinux_manage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-services.md
+++ b/openela8/topics/cockpit-services.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Manage Services
 
 **Parent topic:**[System Monitoring Actions](../topics/cockpit-monitor.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-softwaremanage.md
+++ b/openela8/topics/cockpit-softwaremanage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Software Updates
 
 -   **[Apply Pending Software Updates Manually](../topics/cockpit-softwaremanage_manage_manual_software_updates.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-softwaremanage_manage_automatic_software_updates.md
+++ b/openela8/topics/cockpit-softwaremanage_manage_automatic_software_updates.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Schedule Automatic Software Updates
 
 **Parent topic:**[Software Updates](../topics/cockpit-softwaremanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-softwaremanage_manage_manual_software_updates.md
+++ b/openela8/topics/cockpit-softwaremanage_manage_manual_software_updates.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Apply Pending Software Updates Manually
 
 **Parent topic:**[Software Updates](../topics/cockpit-softwaremanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-storage_management.md
+++ b/openela8/topics/cockpit-storage_management.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Storage Management Tasks
 
 -   **[Storage Management Installation and Overview](../topics/cockpit_storage_information.md)**  
@@ -16,8 +20,4 @@
 
 -   **[Manage Connections to iSCSI Targets](../topics/cockpit_iscsi_targets.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-system_join_a_domain.md
+++ b/openela8/topics/cockpit-system_join_a_domain.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Join an Active Directory Domain
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-tuned.md
+++ b/openela8/topics/cockpit-tuned.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Tuned Performance Profile
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-usermanage.md
+++ b/openela8/topics/cockpit-usermanage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # User Management Actions
 
 -   **[Create or Change User Accounts](../topics/cockpit-usermanage_create_a_user.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-usermanage_access_the_accounts_page.md
+++ b/openela8/topics/cockpit-usermanage_access_the_accounts_page.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Disconnect User Sessions or Remove User Accounts
 
 **Parent topic:**[User Management Actions](../topics/cockpit-usermanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-usermanage_create_a_user.md
+++ b/openela8/topics/cockpit-usermanage_create_a_user.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create or Change User Accounts
 
 **Parent topic:**[User Management Actions](../topics/cockpit-usermanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-volgroups.md
+++ b/openela8/topics/cockpit-volgroups.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Volume Group Properties
 
 -   **[Add New Drive to a Volume Group](../topics/cockpit-volgroups_add_physical_drives_to_volume_groups.md)**  
@@ -12,8 +16,4 @@
 
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-volgroups_add_physical_drives_to_volume_groups.md
+++ b/openela8/topics/cockpit-volgroups_add_physical_drives_to_volume_groups.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add New Drive to a Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit-volgroups_remove_physical_drives_from_volume_groups.md
+++ b/openela8/topics/cockpit-volgroups_remove_physical_drives_from_volume_groups.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Physical Drive From Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit_disk_rates.md
+++ b/openela8/topics/cockpit_disk_rates.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View Disk Read and Write Rates
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit_host_security_considerations.md
+++ b/openela8/topics/cockpit_host_security_considerations.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Security Considerations for Multiple Host Management
 
 **Parent topic:**[Management of Multiple Hosts](../topics/cockpit-manage_multiple_hosts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit_iscsi_targets.md
+++ b/openela8/topics/cockpit_iscsi_targets.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Connections to iSCSI Targets
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit_mgmt_cdrom_vm.md
+++ b/openela8/topics/cockpit_mgmt_cdrom_vm.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Insert or Remove Virtual CD-ROM on Virtual Machine
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit_overview.md
+++ b/openela8/topics/cockpit_overview.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Cockpit Web Console Overview
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/cockpit_storage_information.md
+++ b/openela8/topics/cockpit_storage_information.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Storage Management Installation and Overview
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/common_administration.md
+++ b/openela8/topics/common_administration.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Common Host Administration Tasks
 
 -   **[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)**  
@@ -10,8 +14,4 @@
 
 -   **[Software Updates](../topics/cockpit-softwaremanage.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/configure_network_bridging.md
+++ b/openela8/topics/configure_network_bridging.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network Bridging Properties
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/configure_networking_vlans.md
+++ b/openela8/topics/configure_networking_vlans.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network VLAN Properties
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/create_clone_or_migrate_a_virtual_machine.md
+++ b/openela8/topics/create_clone_or_migrate_a_virtual_machine.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create, Import, Clone, or Migrate a VM Instance
 
 -   **[Create a VM Instance](../topics/cockpit-kvm_create_a_virtual_machine.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/diag_reports_evaluate_issues.md
+++ b/openela8/topics/diag_reports_evaluate_issues.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Evaluate System Problems Using Diagnostic Reports
 
 -   **[Generate Diagnostic Reports](../topics/diag_reports_generate.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Debugging Tools](../topics/manage_host_debugging_tools.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/diag_reports_generate.md
+++ b/openela8/topics/diag_reports_generate.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Generate Diagnostic Reports
 
 **Parent topic:**[Evaluate System Problems Using Diagnostic Reports](../topics/diag_reports_evaluate_issues.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/diag_reports_rm_dwnld.md
+++ b/openela8/topics/diag_reports_rm_dwnld.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Download or Remove Generated Reports
 
 **Parent topic:**[Evaluate System Problems Using Diagnostic Reports](../topics/diag_reports_evaluate_issues.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/disable_smt.md
+++ b/openela8/topics/disable_smt.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Disable SMT to Prevent CPU Security Issues
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/display_mode.md
+++ b/openela8/topics/display_mode.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Cockpit Background Theme
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/extend_cockpit.md
+++ b/openela8/topics/extend_cockpit.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Extend Cockpit's Functionality
 
 -   **[Install and Manage Add-on Applications](../topics/manage_add_on_applications.md)**  
 
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/firewall-ConfiguringaPacketFilteringFirewall.md
+++ b/openela8/topics/firewall-ConfiguringaPacketFilteringFirewall.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a Packet Filtering Firewall
 
 ## About Packet-Filtering Firewalls
@@ -31,8 +35,4 @@
 ### Using the firewall-cmd Command
 
 ### Using a Zone Configuration File
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/firewall-UsingthenftablesFramework.md
+++ b/openela8/topics/firewall-UsingthenftablesFramework.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using the nftables Framework
 
 ## Converting iptables to nftables
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/fsadmin-AboutFileSystemManagementinEnterpriseLinux.md
+++ b/openela8/topics/fsadmin-AboutFileSystemManagementinEnterpriseLinux.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About File System Management
 
 ## Supported File Systems
 
 ## Maximum File and File System Size Requirements
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/fsadmin-ManagingtheExtFileSystem.md
+++ b/openela8/topics/fsadmin-ManagingtheExtFileSystem.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing the Ext File System
 
 ## Converting a Non Root Ext File System to a Later Version
@@ -7,8 +11,4 @@
 ## Checking and Repairing an Ext File System
 
 ## Changing the Frequency of File System Checking for Ext File Systems
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/fsadmin-ManagingtheXFSFileSystem.md
+++ b/openela8/topics/fsadmin-ManagingtheXFSFileSystem.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing the XFS File System
 
 ## Installing XFS Packages
@@ -19,8 +23,4 @@
 ## Checking and Repairing an XFS File System
 
 ## Defragmenting an XFS File System
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/fsadmin-PerformingBasicFileSystemAdministration.md
+++ b/openela8/topics/fsadmin-PerformingBasicFileSystemAdministration.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Performing Basic File System Administration
 
 ## Building File Systems
@@ -43,8 +47,4 @@
 ### Reporting on Disk Quota Usage
 
 ### Maintaining the Accuracy of Disk Quota Reporting
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/manage_add_on_applications.md
+++ b/openela8/topics/manage_add_on_applications.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Manage Add-on Applications
 
 **Parent topic:**[Extend Cockpit's Functionality](../topics/extend_cockpit.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/manage_host_debugging_tools.md
+++ b/openela8/topics/manage_host_debugging_tools.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Debugging Tools
 
 -   **[Evaluate System Problems Using Diagnostic Reports](../topics/diag_reports_evaluate_issues.md)**  
 
 -   **[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/managing_system_certificates.md
+++ b/openela8/topics/managing_system_certificates.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing System Certificates
 
 ## Using the trust Command To Manage System Certificates
 
 ## Manually Updating Trusted Certificates
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/modify_crypto.md
+++ b/openela8/topics/modify_crypto.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change System-Wide Crypto Policy
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/nbde-AboutNetworkBoundDiskEncryption.md
+++ b/openela8/topics/nbde-AboutNetworkBoundDiskEncryption.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Network-Bound Disk Encryption
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/nbde-InstallandConfigureaTangServer.md
+++ b/openela8/topics/nbde-InstallandConfigureaTangServer.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Configure a Tang Server
 
 ## Install the Tang Package and Enable the Tang Socket in Systemd
@@ -11,8 +15,4 @@
 ## Initialize Tang Signing Keys
 
 ## Rotate Tang Keys
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/nbde-PerformAutomatedEncryptionandDecryptionWithClevis.md
+++ b/openela8/topics/nbde-PerformAutomatedEncryptionandDecryptionWithClevis.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Perform Automated Encryption and Decryption With Clevis
 
 ## Install and Test Clevis
@@ -17,8 +21,4 @@
 ### Update Clevis for Tang Key Rotation
 
 ### Unbind Clevis from a LUKS Slot
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/network-AboutNetworkAddressTranslation.md
+++ b/openela8/topics/network-AboutNetworkAddressTranslation.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Network Address Translation
 
 Network Address Translation \(NAT\) is a process that assigns a public address to a computer or a group of computers inside a private network by using a different address scheme. The public IP address masquerades all the requests as though they're going to one server, rather than several servers. NAT is useful for limiting the number of public IP addresses that an organization must finance. NAT also provides extra security by hiding the details of internal networks.
@@ -21,8 +25,4 @@ sudo sysctl -w net.ipv4.ip_forward=0|1
 The new status is displayed when you run the command. To make the change persist across system reboots, copy the command output line and add it to the `/etc/sysctl.conf` file.
 
 You can also use the Firewall Configuration GUI \(`firewall-config`\) to configure masquerading and port forwarding.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/network-ConfiguringDHCPServices.md
+++ b/openela8/topics/network-ConfiguringDHCPServices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring DHCP Services
 
 The Dynamic Host Configuration Protocol \(DHCP\) enables client systems to obtain network configuration information from a DHCP server each time they connect to the network. The DHCP server is configured with a range of IP addresses and other network configuration parameters that clients need.
@@ -461,8 +465,4 @@ Ensure that you have the required administrative privileges and complete the fol
         sudo systemctl start dhcpd6
         ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/network-ConfiguringNetworkTime.md
+++ b/openela8/topics/network-ConfiguringNetworkTime.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring Network Time
 
 This chapter describes how to configure a system to use `chrony` as an implementation of the Network Time Protocol \(NTP\) feature, as a replacement for `ntp`. The chapter also describes the Precision Time Protocol \(PTP\) daemons that are used to set the system time.
@@ -439,8 +443,4 @@ These entries define the local system clock as the time reference.
 **Note:**
 
 Don't configure any added `server` lines in the file.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/network-ConfiguringtheNameService.md
+++ b/openela8/topics/network-ConfiguringtheNameService.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring the Name Service
 
 This chapter describes how to use Berkeley Internet Name Domain \(BIND\) to set up a Domain Name System \(DNS\) name server.
@@ -568,8 +572,4 @@ Received 72 bytes from 10.0.0.1#53 in 32 ms
 ```
 
 For more information, see the `host(1)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/network-ConfiguringtheSystemsNetwork.md
+++ b/openela8/topics/network-ConfiguringtheSystemsNetwork.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring the System's Network
 
 To enable the system to connect to the network, transmit and receive traffic with other systems, you would need to configure the system to have identifiable names, IP addresses, routes, and so on. Depending on the system's available resources, you can further optimize the network configuration to attain high availability and improved performance by implementing added network technologies such as network bonds, teams, and multipathing.
@@ -667,8 +671,4 @@ To convert the `NetworkManager` legacy `ifcfg` profile formats to the preferred 
     nmcli -f TYPE,FILENAME,NAME connection
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/network-OptimizingNetworkServersforHighAvailability.md
+++ b/openela8/topics/network-OptimizingNetworkServersforHighAvailability.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Optimizing Network Servers for High Availability
 
 For systems that provide network services to clients inside the network, network availability becomes a priority to ensure that the services are continuous and interruptions are prevented. With virtual local area networks \(VLANs\), you can also organize the network such that systems with similar functions are grouped together as though they belong to their own virtual networks. This feature improves network management and administration.
@@ -190,8 +194,4 @@ sudo ip link add link eth1 name eth1.5 type vlan id 5
 ```
 
 For more information, see the `ip(8)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/openssh-AboutOpenSSH.md
+++ b/openela8/topics/openssh-AboutOpenSSH.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About OpenSSH
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/openssh-ConfigureOpenSSHClient.md
+++ b/openela8/topics/openssh-ConfigureOpenSSHClient.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring the OpenSSH Client
 
 ## Installing the OpenSSH Client Packages
@@ -5,8 +9,4 @@
 ## Configuring OpenSSH Client Configuration Files
 
 ## Validating Configuration Permissions
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/openssh-ConfiguringOpenSSHServer.md
+++ b/openela8/topics/openssh-ConfiguringOpenSSHServer.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring OpenSSH Server
 
 ## Installing OpenSSH Server and Enabling sshd
@@ -16,8 +20,4 @@
 ### Restricting SSH Key Access to Specific Commands
 
 ## Good Practice Recommendations for Configuring OpenSSH Server
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/openssh-UsingOpenSSHClientUtilities.md
+++ b/openela8/topics/openssh-UsingOpenSSHClientUtilities.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using OpenSSH Client Utilities
 
 ## Connecting to Another System Using the ssh Command
@@ -15,8 +19,4 @@
 ## Using X11 Forwarding to Load Remote Graphical Applications
 
 ## Setting Up Port Forwarding Over SSH
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/openssh-WorkingwithSSHKeyPairs.md
+++ b/openela8/topics/openssh-WorkingwithSSHKeyPairs.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working with SSH Key Pairs
 
 ## How SSH Key Pairs Work
@@ -23,8 +27,4 @@
 [Working With OpenSSH Server Configuration Files](openssh-ConfiguringOpenSSHServer.md#)
 
 ## Good Practice Recommendations for Working with SSH Key Pairs
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/osmanage-ConfiguringSystemSettings.md
+++ b/openela8/topics/osmanage-ConfiguringSystemSettings.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring System Settings
 
 This chapter describes the files and virtual file systems that you can use to change the configuration settings for the system.
@@ -922,8 +926,4 @@ sudo systemctl enable --now watchdog
 The Watchdog service immediately starts and runs in the background.
 
 **Note:** The Watchdog service starts and runs immediately after a power reset.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/osmanage-ManagingKernelModules.md
+++ b/openela8/topics/osmanage-ManagingKernelModules.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Kernel Modules
 
 This chapter describes how to load, unload, and modify the behavior of kernel modules.
@@ -361,8 +365,4 @@ You can also use the `weak-modules` command with the `dry-run` option to test th
 weak-modules --remove-kernel --dry-run --verbose
 rm -rf kmod-kvdo
 ```
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/osmanage-ManagingResources.md
+++ b/openela8/topics/osmanage-ManagingResources.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Resources
 
 This chapter describes how to manage the use of resources in an Enterprise Linux system.
@@ -599,8 +603,4 @@ As a prerequisite to the following procedure, you must complete the preparations
 ## Using cgroups v2 to Manage Resources for Users
 
 The previous sample procedures describe how to manage applications' use of system resources. You can also manage resource use by directly implementing resource filters to users who log in to the system.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/osmanage-ManagingSystemDevices.md
+++ b/openela8/topics/osmanage-ManagingSystemDevices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing System Devices
 
 This chapter describes how the system uses device files and how the Udev device manager dynamically creates or removes device node files.
@@ -777,8 +781,4 @@ The following example illustrates how to implement a `udev` rules file that adds
 
 4.  \(Optional\) To undo the changes, remove `/etc/udev/rules.d/10-local.rules` and `/dev/my_disk`, then run `systemctl restart systemd-udevd` again.
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/osmanage-WorkingWithSystemServices.md
+++ b/openela8/topics/osmanage-WorkingWithSystemServices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing System Services With systemd
 
 The`systemd` daemon is the system initialization and service manager in Enterprise Linux. This chapter describes how to use `systemd`to manage system processes, services and `systemd` targets.
@@ -1005,8 +1009,4 @@ The following examples show how to use `systemd-run` to activate transient timer
     sudo systemd-run --on-calendar="17:00:00"
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/osmanage-WorkingWiththeGRUB2BootloaderandConfiguringBootServices.md
+++ b/openela8/topics/osmanage-WorkingWiththeGRUB2BootloaderandConfiguringBootServices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Kernels and System Boot
 
 This chapter describes the Enterprise Linux boot process and how to configure and use the GRand Unified Bootloader \(GRUB\) version 2 and boot-related kernel parameters.
@@ -345,8 +349,4 @@ To modify the boot parameters for the GRUB 2 configuration so that these paramet
 For systems that boot with UEFI, the `grub.cfg` file is located in the `/boot/efi/EFI/redhat` directory because the boot configuration is stored on a dedicated FAT32-formatted partition.
 
 After the system has successfully booted, the `EFI` folder on that partition is mounted inside the `/boot/efi` directory on the root file system for Enterprise Linux.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_add_pod_container.md
+++ b/openela8/topics/podman_add_pod_container.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add a Container to a Pod Group
 
 **Parent topic:**[Podman Pod Management](../topics/podman_pod_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_commit_changes.md
+++ b/openela8/topics/podman_commit_changes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Commit Container Changes to Create New Image
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_container_checkpoint_restore.md
+++ b/openela8/topics/podman_container_checkpoint_restore.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Checkpoint and Restore a System Container
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_container_inspect_access_cli.md
+++ b/openela8/topics/podman_container_inspect_access_cli.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Inspect Container and Access Container Logs and CLI
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_container_mgmt.md
+++ b/openela8/topics/podman_container_mgmt.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create and Run Container
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_container_remove.md
+++ b/openela8/topics/podman_container_remove.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Container or Pod Group
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_container_rename_stop_start.md
+++ b/openela8/topics/podman_container_rename_stop_start.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Rename, Pause, Stop, or Restart Container
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_create_pod_group.md
+++ b/openela8/topics/podman_create_pod_group.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Pod Group
 
 **Parent topic:**[Podman Pod Management](../topics/podman_pod_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_image_download.md
+++ b/openela8/topics/podman_image_download.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Search and Download New Images
 
 **Parent topic:**[Podman Image Management](../topics/cockpit-podman_managing_podman_images.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_inspect_pod.md
+++ b/openela8/topics/podman_inspect_pod.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Inspect and Change a Pod Group
 
 **Parent topic:**[Podman Pod Management](../topics/podman_pod_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_pod_management.md
+++ b/openela8/topics/podman_pod_management.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Pod Management
 
 -   **[Create a Pod Group](../topics/podman_create_pod_group.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_remove_image.md
+++ b/openela8/topics/podman_remove_image.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Images
 
 **Parent topic:**[Podman Image Management](../topics/cockpit-podman_managing_podman_images.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_special_considerations.md
+++ b/openela8/topics/podman_special_considerations.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Special Considerations for Non Administrator Containers
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/podman_view_image.md
+++ b/openela8/topics/podman_view_image.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Inspect Available Images
 
 **Parent topic:**[Podman Image Management](../topics/cockpit-podman_managing_podman_images.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/reboot.md
+++ b/openela8/topics/reboot.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Restart or Power Off System
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/search_sort_view_accts.md
+++ b/openela8/topics/search_sort_view_accts.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Find and Manage Account Information
 
 **Parent topic:**[User Management Actions](../topics/cockpit-usermanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/securitypractice.md
+++ b/openela8/topics/securitypractice.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Security Management Actions
 
 -   **[Disable SMT to Prevent CPU Security Issues](../topics/disable_smt.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/selinux-AboutAdministeringSELinux.md
+++ b/openela8/topics/selinux-AboutAdministeringSELinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Administering SELinux in Enterprise Linux
 
 ## SELinux Package Descriptions
@@ -7,8 +11,4 @@
 ## Setting SELinux Modes
 
 ## Getting More Information
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/selinux-AdministeringSELinuxPolicies.md
+++ b/openela8/topics/selinux-AdministeringSELinuxPolicies.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Administering SELinux Policies
 
 ## Targeted Policy
@@ -7,8 +11,4 @@
 ## Setting or Switching SELinux Policies
 
 ## Customizing SELinux Policies
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/selinux-AdministeringSELinuxSecurityContext.md
+++ b/openela8/topics/selinux-AdministeringSELinuxSecurityContext.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Administering SELinux Security Context
 
 ## Displaying SELinux User Mapping
@@ -9,8 +13,4 @@
 ## Restoring the Default File Type
 
 ## Relabeling a File System
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/selinux-AdministeringSELinuxUsers.md
+++ b/openela8/topics/selinux-AdministeringSELinuxUsers.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Administering SELinux Users
 
 ## Understanding Confined SELinux Users
@@ -7,8 +11,4 @@
 ## Setting the Default User Mapping
 
 ## Configuring the Behavior of Application Execution for Users
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/selinux-TroubleshootingAccessDenialMessages.md
+++ b/openela8/topics/selinux-TroubleshootingAccessDenialMessages.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Troubleshooting Access-Denial Messages
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/selinux_multi_category_security_mcs.md
+++ b/openela8/topics/selinux_multi_category_security_mcs.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Extending SELinux Policies with Multi-Category Security
 
 ## MCS Requirements
@@ -9,8 +13,4 @@
 ## Applying MCS Categories to Files
 
 ## Enabling the mcstrans Service
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/set_host_name.md
+++ b/openela8/topics/set_host_name.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change System Hostname
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/set_session_time_out_for_web_console.md
+++ b/openela8/topics/set_session_time_out_for_web_console.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Set a Timeout for Inactive Sessions
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/set_system_time.md
+++ b/openela8/topics/set_system_time.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change System Date and Time
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/sfw-mgmt-AboutDNFUtility.md
+++ b/openela8/topics/sfw-mgmt-AboutDNFUtility.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About the DNF Utility
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/sfw-mgmt-ConfigureaSystemtoUseEnterpriseLinuxYumServer.md
+++ b/openela8/topics/sfw-mgmt-ConfigureaSystemtoUseEnterpriseLinuxYumServer.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a System to Use Enterprise Linux Yum Server
 
 ## Configuring the Global DNF Configuration Settings
@@ -9,8 +13,4 @@
 ## Editing Yum Repository Configuration Files
 
 ## Using the DNF config-manager Plugin
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/sfw-mgmt-InstallSoftwareonEnterpriseLinux.md
+++ b/openela8/topics/sfw-mgmt-InstallSoftwareonEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Installing Software on Enterprise Linux
 
 ## Using DNF Groups
@@ -11,8 +15,4 @@
 ### How to Remove Installed Modules
 
 ### How to Switch Module Streams
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/sfw-mgmt-UpdateSoftwareonEnterpriseLinux.md
+++ b/openela8/topics/sfw-mgmt-UpdateSoftwareonEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Updating Software on Enterprise Linux
 
 ## Updating Software Automatically
@@ -5,8 +9,4 @@
 ## Disabling Updates for Particular Packages
 
 ## Using DNF to See Security Updates
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/sfw-mgmt-UseSoftwareDistributionMirrors.md
+++ b/openela8/topics/sfw-mgmt-UseSoftwareDistributionMirrors.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using Software Distribution Mirrors
 
 ## Prerequisites for the Local Distribution Mirror
@@ -11,8 +15,4 @@
 ### How to Mirror Repositories From an ISO
 
 ## How to Configure Client Access to the Local Mirror
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/sfw-mgmt-YumV3DNFComparison.md
+++ b/openela8/topics/sfw-mgmt-YumV3DNFComparison.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Comparing Yum Version 3 With DNF
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/shareadmin-AboutSharedFileSystemManagementinEnterpriseLinux.md
+++ b/openela8/topics/shareadmin-AboutSharedFileSystemManagementinEnterpriseLinux.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Shared File System Management
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/shareadmin-ManagingSambainEnterpriseLinux.md
+++ b/openela8/topics/shareadmin-ManagingSambainEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Samba
 
 ## About Samba
@@ -29,8 +33,4 @@
 #### Using `smbclient` Commands
 
 #### Mounting a Samba Share with `cifs`
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/shareadmin-ManagingtheNetworkFileSysteminEnterpriseLinux.md
+++ b/openela8/topics/shareadmin-ManagingtheNetworkFileSysteminEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing the Network File System
 
 ## About NFS
@@ -13,8 +17,4 @@
 ### Configuring an NFS Server by Using the exportfs Command
 
 ## Mounting an NFS File System
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/userauth-AboutSystemAuthentication.md
+++ b/openela8/topics/userauth-AboutSystemAuthentication.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About System Authentication
 
 Authentication is a way of implementing system security by verifying the identity of an entity, such as a user, to a system. A user logs in by providing a username and a password, and the OS authenticates the user's identity by comparing this information to data stored on the system. If the login credentials match and the user account is active, the user is authenticated and can successfully access the system.
@@ -83,8 +87,4 @@ To efficiently manage the variety of profiles, `authselect` stores different typ
 The `authselect` utility applies the specifications in the selected profile. However, `authselect` doesn't change the configuration files of the service on which the profile is based. If, for example, you use the `sssd` profile, you must configure SSSD for the service to function properly. Consult the proper documentation to configure the profile's service. You must also ensure that the service is started and enabled.
 
 For more details about the utility, see the `authselect(8)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/userauth-GrantingsudoAccesstoUsers.md
+++ b/openela8/topics/userauth-GrantingsudoAccesstoUsers.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Granting sudo Access to Users
 
 In Enterprise Linux, only administrators can perform privileged tasks on the system.
@@ -239,8 +243,4 @@ Or, you can set group permissions directly in the `/etc/sudoers` file. For examp
     sudo usermod -aG wheel bob
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/userauth-MigratingFromauthconfigtoauthselect.md
+++ b/openela8/topics/userauth-MigratingFromauthconfigtoauthselect.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Migrating From authconfig to authselect
 
 Beginning with Enterprise Linux 8, `authselect` has replaced `authconfig` that was used in prior releases. Compatibility between the two utilities is minimal. Thus, migrating to `authselect` is highly recommended. Migrating requires you to complete several actions, including the following:
@@ -26,8 +30,4 @@ Beginning with Enterprise Linux 8, `authselect` has replaced `authconfig` that w
 
 
 For complete migration instructions and examples, see the `authselect-migration(7)` manual page. See also the `authselect(8)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/userauth-UsingtheSystemSecurityServicesDaemon.md
+++ b/openela8/topics/userauth-UsingtheSystemSecurityServicesDaemon.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using the System Security Services Daemon
 
 The System Security Services Daemon \(SSSD\) feature provides access on a client system to remote identity and authentication providers. The SSSD acts as an intermediary between local clients and any back-end provider that you configure.
@@ -221,8 +225,4 @@ The `include` flag specifies that PAM must also consult the PAM configuration fi
 Most authentication modules and PAM configuration files have their own manual pages. Relevant files are stored in the `/usr/share/doc/pam` directory.
 
 For more information, see the `pam(8)` manual page. In addition, each PAM module has its own manual page, for example `pam_unix(8)`, `postlogin(5)`, and `system-auth(5)`.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/userauth-WorkingWithSystemAuthenticationProfiles.md
+++ b/openela8/topics/userauth-WorkingWithSystemAuthenticationProfiles.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working With System Authentication Profiles
 
 The `authselect` command has various subcommands, arguments, and options to create, delete, switch to a different profile, and modify profile features. A user must have the appropriate privileges to be able to use this configuration tool.
@@ -305,8 +309,4 @@ If you do not want to use the profiles included in Enterprise Linux or those pro
     sudo authselect current
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/userauth-WorkingWithUserandGroupAccounts.md
+++ b/openela8/topics/userauth-WorkingWithUserandGroupAccounts.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working With User and Group Accounts
 
 By default, a new installation of Enterprise Linux uses local user and group accounts for authentication, permissions handling, and access to resources. When working with local accounts for users and groups, you use three main commands: `useradd`, `groupadd`, and `usermod`. Through these commands and their different options, you can add or delete users and groups, as well as modify user or group settings.
@@ -262,8 +266,4 @@ sudo useradd -D -f 30
 A value of -1 specifies that user accounts aren't locked because of inactivity.
 
 For more information, see the `useradd(8)` and `usermod(8)` manual pages.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/view_system.md
+++ b/openela8/topics/view_system.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Health, Usage, and System Details
 
 **Parent topic:**[System Monitoring Actions](../topics/cockpit-monitor.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/vpn-AboutVirtualPrivateNetworks.md
+++ b/openela8/topics/vpn-AboutVirtualPrivateNetworks.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Virtual Private Networks
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/vpn-ConfiguringaVPNbyUsingLibreswan.md
+++ b/openela8/topics/vpn-ConfiguringaVPNbyUsingLibreswan.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a VPN by Using Libreswan
 
 ## Installing Libreswan
@@ -9,8 +13,4 @@
 ### Creating a Site to Site Connection
 
 ## Verifying the Status of VPN Services
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela8/topics/vpn-ConfiguringaVPNbyUsingWireGuard.md
+++ b/openela8/topics/vpn-ConfiguringaVPNbyUsingWireGuard.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a VPN by Using WireGuard
 
 ## Installing WireGuard
@@ -9,8 +13,4 @@
 ## Testing the WireGuard Tunnel
 
 ## Shutting Down the WireGuard Tunnel
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/README.md
+++ b/openela9/README.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # OpenELA 9
 
 -   Managing Core System Configuration
@@ -429,7 +433,7 @@
                     -   [Create a CA Root Configuration File](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-root-conf)
                     -   [Create and Verify the CA Root Key Pair](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-root-keys)
                 -   [Create an intermediary CA](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary)
-                    -   [Create A CA Directory Structure](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#unique_1649262594)
+                    -   [Create A CA Directory Structure](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#unique_861993555)
                     -   [Create the intermediary CA Configuration](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary-conf)
                     -   [Create a CSR for the intermediary CA](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary-csr)
                     -   [Create a signed certificate for the intermediary CA](topics/certmanage-UsingOpenSSLinEnterpriseLinux.md#openssl-ca-intermediary-sign)
@@ -607,7 +611,4 @@
             -   [Creating a Host to Host Connection](topics/vpn-ConfiguringaVPNbyUsingLibreswan.md#vpn-host2host)
             -   [Creating a Site to Site Connection](topics/vpn-ConfiguringaVPNbyUsingLibreswan.md#vpn-site2site)
         -   [Verifying the Status of VPN Services](topics/vpn-ConfiguringaVPNbyUsingLibreswan.md#verify-libreswan)
-
----
-<!-- Copyright © 2023, Oracle and/or its affiliates. -->
 

--- a/openela9/topics/DNFCommandRef.md
+++ b/openela9/topics/DNFCommandRef.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # DNF Command References
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/accessibility-CustomizingAccessibilityFeatures.md
+++ b/openela9/topics/accessibility-CustomizingAccessibilityFeatures.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Customizing Accessibility Features
 
 ## Configuring the Screen Reader
@@ -7,8 +11,4 @@
 ## Configuring Typing Assist
 
 ## Configuring Click Assist
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/accessibility-OverviewofAccessibilityFeatures.md
+++ b/openela9/topics/accessibility-OverviewofAccessibilityFeatures.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Overview of Accessibility Features
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/accessibility-UsingBraille.md
+++ b/openela9/topics/accessibility-UsingBraille.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using Braille
 
 ## Configuring Braille Options on the Screen Reader
 
 ## Configuring the BRLTTY Service
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/accessibility-WorkingWithAccessibilityFeaturesinEnterpriseLinux.md
+++ b/openela9/topics/accessibility-WorkingWithAccessibilityFeaturesinEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working With Accessibility Features in Enterprise Linux 9
 
 ## Selecting a Desktop Version
@@ -11,8 +15,4 @@
 ### Using the Classic Desktop
 
 ### Configuring Quick Access
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/add_and_enable_a_firewall_service.md
+++ b/openela9/topics/add_and_enable_a_firewall_service.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Control Access to Zone Services
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/backup-about-backup.md
+++ b/openela9/topics/backup-about-backup.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Backup and Disaster Recovery
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/backup-ol-backup-rear-about.md
+++ b/openela9/topics/backup-ol-backup-rear-about.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Backups With ReaR
 
 ## Installing ReaR
@@ -21,8 +25,4 @@
 ## Recovering a System With ReaR
 
 ## Creating Multiple Backups With ReaR
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/backup-snapshots-data-mirroring.md
+++ b/openela9/topics/backup-snapshots-data-mirroring.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Backups With File System Snapshots and Data Mirroring
 
 ## Working With File System Snapshots
@@ -9,8 +13,4 @@
 ### Managing Geo-Replicated Data With Gluster Storage for Enterprise Linux
 
 ### Managing Block Device Redundancy With Software RAID
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/balancing-AboutLoadBalancinginEnterpriseLinux.md
+++ b/openela9/topics/balancing-AboutLoadBalancinginEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Load Balancing in Enterprise Linux
 
 ## About Load Balancing
@@ -11,8 +15,4 @@
 ## About Combining Keepalived With HAProxy for High-Availability Load Balancing
 
 ## About NGINX
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/balancing-SettingUpLoadBalancingbyUsingHAProxy.md
+++ b/openela9/topics/balancing-SettingUpLoadBalancingbyUsingHAProxy.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up Load Balancing by Using HAProxy
 
 ## Installing and Configuring HAProxy
@@ -9,8 +13,4 @@
 ## Using Weighted Round Robin Load Balancing with HAProxy
 
 ## Adding Session Persistence for HAProxy
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/balancing-SettingUpLoadBalancingbyUsingKeepalived.md
+++ b/openela9/topics/balancing-SettingUpLoadBalancingbyUsingKeepalived.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up Load Balancing by Using Keepalived
 
 ## Installing and Configuring Keepalived
@@ -11,8 +15,4 @@
 ### Configuring Backend Server Routing for Keepalived NAT-Mode Load Balancing
 
 ## Enhancing Load Balancing by Using Keepalived With HAProxy
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/balancing-SettingUpLoadBalancingbyUsingNGINX.md
+++ b/openela9/topics/balancing-SettingUpLoadBalancingbyUsingNGINX.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up Load Balancing by Using NGINX
 
 ## Installing NGINX
@@ -11,8 +15,4 @@
 ## Using Least-Connected Load Balancing With NGINX
 
 ## Adding Session Persistence for NGINX
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/banner_creation_dita.md
+++ b/openela9/topics/banner_creation_dita.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Cockpit Login Banner
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/certmanage-AboutPublicKeyInfrastructure.md
+++ b/openela9/topics/certmanage-AboutPublicKeyInfrastructure.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Public Key Infrastructure
 
 ## What is Public Key Cryptography?
 
 ## Automatic Certificate Management Environment \(ACME\)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/certmanage-UsingOpenSSLinEnterpriseLinux.md
+++ b/openela9/topics/certmanage-UsingOpenSSLinEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up TLS/SSL with OpenSSL
 
 ## Creating Key Pairs
@@ -57,8 +61,4 @@
 ## Using OpenSSL for File Encryption and Validation
 
 ## More information About OpenSSL
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/certmanage-other-tools.md
+++ b/openela9/topics/certmanage-other-tools.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Setting Up TLS/SSL with Other Tools
 
 ## GnuTLS
@@ -5,8 +9,4 @@
 ## NSS
 
 ## Java
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-config_host_tasks.md
+++ b/openela9/topics/cockpit-config_host_tasks.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # General Host Configuration Actions
 
 -   **[Change System Hostname](../topics/set_host_name.md)**  
@@ -12,8 +16,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-hosts_add_secondary_host.md
+++ b/openela9/topics/cockpit-hosts_add_secondary_host.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add and Connect to Secondary Host
 
 **Parent topic:**[Management of Multiple Hosts](../topics/cockpit-manage_multiple_hosts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-hosts_remove_secondary_host.md
+++ b/openela9/topics/cockpit-hosts_remove_secondary_host.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Edit or Remove Secondary Host
 
 **Parent topic:**[Management of Multiple Hosts](../topics/cockpit-manage_multiple_hosts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-install.md
+++ b/openela9/topics/cockpit-install.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Get Started: Cockpit Web Console
 
 -   **[Cockpit Web Console Overview](../topics/cockpit_overview.md)**  
@@ -12,8 +16,4 @@
 
 -   **[Extend Cockpit's Functionality](../topics/extend_cockpit.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-install_install_the_cockpit_package.md
+++ b/openela9/topics/cockpit-install_install_the_cockpit_package.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Enable Cockpit
 
 **Parent topic:**[Installation and Log In](../topics/cockpit-install_section.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-install_logging_into_cockpit.md
+++ b/openela9/topics/cockpit-install_logging_into_cockpit.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Log in to the Cockpit Web Console
 
 **Parent topic:**[Installation and Log In](../topics/cockpit-install_section.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-install_section.md
+++ b/openela9/topics/cockpit-install_section.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Installation and Log In
 
 -   **[Install and Enable Cockpit](../topics/cockpit-install_install_the_cockpit_package.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kdump.md
+++ b/openela9/topics/cockpit-kdump.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Capture Crash Dump Details Using Kdump
 
 -   **[Overview of Crash Recovery in Kdump](../topics/cockpit-kdump_access_the_kernel_dump_information.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Debugging Tools](../topics/manage_host_debugging_tools.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kdump_access_the_kernel_dump_information.md
+++ b/openela9/topics/cockpit-kdump_access_the_kernel_dump_information.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Overview of Crash Recovery in Kdump
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kdump_enable_kdump_configure_memory_and_specify_the_crash_dump_location.md
+++ b/openela9/topics/cockpit-kdump_enable_kdump_configure_memory_and_specify_the_crash_dump_location.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Crash Dump Target Location
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kdump_modify_kdump_service_at_boot.md
+++ b/openela9/topics/cockpit-kdump_modify_kdump_service_at_boot.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Kdump Service State
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kdump_test_your_kdump_settings.md
+++ b/openela9/topics/cockpit-kdump_test_your_kdump_settings.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Test the Kdump Configuration
 
 **Parent topic:**[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm.md
+++ b/openela9/topics/cockpit-kvm.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Virtual Machine \(VM\) Management Tasks
 
 -   **[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)**  
@@ -16,8 +20,4 @@
 
 -   **[Share a Host Directory with VM Instance](../topics/cockpit-kvm_mountshared_directory.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_attach_host.md
+++ b/openela9/topics/cockpit-kvm_attach_host.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Attach or Remove VM Host Devices
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_check_the_storage_pools.md
+++ b/openela9/topics/cockpit-kvm_check_the_storage_pools.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Storage Pool
 
 **Parent topic:**[Manage Storage Pools for VM Instances](../topics/cockpit-kvm_manage_storage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_clone_vm.md
+++ b/openela9/topics/cockpit-kvm_clone_vm.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Clone an Existing VM Instance
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_console.md
+++ b/openela9/topics/cockpit-kvm_console.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Console for VM Interaction
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_cpu_mem_autostart.md
+++ b/openela9/topics/cockpit-kvm_cpu_mem_autostart.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Edit Memory, CPU, Autostart, or Watchdog Properties
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_create_a_virtual_machine.md
+++ b/openela9/topics/cockpit-kvm_create_a_virtual_machine.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a VM Instance
 
 -   **[Install Cockpit-Machines and Enable Virtualization](../topics/cockpit-kvm_install_the_cockpit_virtual_machines_module.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_delete_storage_pool.md
+++ b/openela9/topics/cockpit-kvm_delete_storage_pool.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Existing Storage Pools
 
 **Parent topic:**[Manage Storage Pools for VM Instances](../topics/cockpit-kvm_manage_storage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_disk.md
+++ b/openela9/topics/cockpit-kvm_disk.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add, Edit, or Remove Disks
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_import_vm.md
+++ b/openela9/topics/cockpit-kvm_import_vm.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Import a VM From a Disk Image
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_install_the_cockpit_virtual_machines_module.md
+++ b/openela9/topics/cockpit-kvm_install_the_cockpit_virtual_machines_module.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install Cockpit-Machines and Enable Virtualization
 
 **Parent topic:**[Create a VM Instance](../topics/cockpit-kvm_create_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_manage_instance.md
+++ b/openela9/topics/cockpit-kvm_manage_instance.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure VM Devices and Services
 
 -   **[Edit Memory, CPU, Autostart, or Watchdog Properties](../topics/cockpit-kvm_cpu_mem_autostart.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_manage_storage.md
+++ b/openela9/topics/cockpit-kvm_manage_storage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Storage Pools for VM Instances
 
 -   **[Create a Storage Pool](../topics/cockpit-kvm_check_the_storage_pools.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_migrate_virtual_machine.md
+++ b/openela9/topics/cockpit-kvm_migrate_virtual_machine.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Requirements to Migrate Virtual Machine
 
 **Parent topic:**[Migrate a Running VM to Another KVM Host](../topics/cockpit-kvm_migrate_vm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_migrate_vm.md
+++ b/openela9/topics/cockpit-kvm_migrate_vm.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Migrate a Running VM to Another KVM Host
 
 -   **[Requirements to Migrate Virtual Machine](../topics/cockpit-kvm_migrate_virtual_machine.md)**  
 
 
 **Parent topic:**[Create, Import, Clone, or Migrate a VM Instance](../topics/create_clone_or_migrate_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_mountshared_directory.md
+++ b/openela9/topics/cockpit-kvm_mountshared_directory.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Share a Host Directory with VM Instance
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_network_interface.md
+++ b/openela9/topics/cockpit-kvm_network_interface.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add, Edit, Unplug, or Plug VM Network Interface
 
 **Parent topic:**[Configure VM Devices and Services](../topics/cockpit-kvm_manage_instance.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_reboot_shutdown.md
+++ b/openela9/topics/cockpit-kvm_reboot_shutdown.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Start, Shutdown, Remove, or Interrupt a VM Instance
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_snapshot.md
+++ b/openela9/topics/cockpit-kvm_snapshot.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create, Delete, or Revert a Snapshot of VM Instance
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-kvm_video_demonstration.md
+++ b/openela9/topics/cockpit-kvm_video_demonstration.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Video Demonstration
 
 **Parent topic:**[Create a VM Instance](../topics/cockpit-kvm_create_a_virtual_machine.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-luks.md
+++ b/openela9/topics/cockpit-luks.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Encrypt Block Devices With LUKS
 
 -   **[Lock Disk Device With LUKs](../topics/cockpit-luks_lock_data_on_a_device_with_luks.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-luks_change_the_luks_configuration.md
+++ b/openela9/topics/cockpit-luks_change_the_luks_configuration.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Passphrase Key for LUKS Encryption
 
 **Parent topic:**[Encrypt Block Devices With LUKS](../topics/cockpit-luks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-luks_lock_data_on_a_device_with_luks.md
+++ b/openela9/topics/cockpit-luks_lock_data_on_a_device_with_luks.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Lock Disk Device With LUKs
 
 **Parent topic:**[Encrypt Block Devices With LUKS](../topics/cockpit-luks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm.md
+++ b/openela9/topics/cockpit-lvm.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Logical Volumes With LVM
 
 -   **[Create a Volume Group](../topics/cockpit-lvm_create_volume_groups.md)**  
@@ -14,8 +18,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_create_logical_volumes.md
+++ b/openela9/topics/cockpit-lvm_create_logical_volumes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Logical Volume
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_create_volume_groups.md
+++ b/openela9/topics/cockpit-lvm_create_volume_groups.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Volume Group
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_format_logical_volumes.md
+++ b/openela9/topics/cockpit-lvm_format_logical_volumes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Format and Mount a Logical Volume
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_overview.md
+++ b/openela9/topics/cockpit-lvm_overview.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Rename a Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_remove_logical_volume.md
+++ b/openela9/topics/cockpit-lvm_remove_logical_volume.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Logical Volume From Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_remove_vol_groupdita.md
+++ b/openela9/topics/cockpit-lvm_remove_vol_groupdita.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_resize_logical_volumes.md
+++ b/openela9/topics/cockpit-lvm_resize_logical_volumes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Resize Logical Volumes
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-lvm_thin-logical-volume.md
+++ b/openela9/topics/cockpit-lvm_thin-logical-volume.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Thin Logical Volume
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-manage_multiple_hosts.md
+++ b/openela9/topics/cockpit-manage_multiple_hosts.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Management of Multiple Hosts
 
 -   **[Security Considerations for Multiple Host Management](../topics/cockpit_host_security_considerations.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-monitor.md
+++ b/openela9/topics/cockpit-monitor.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # System Monitoring Actions
 
 -   **[Health, Usage, and System Details](../topics/view_system.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-monitor_using_available_quantifiers.md
+++ b/openela9/topics/cockpit-monitor_using_available_quantifiers.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Filter Log Entries
 
 **Parent topic:**[System Monitoring Actions](../topics/cockpit-monitor.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-nbde.md
+++ b/openela9/topics/cockpit-nbde.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Unlock Encrypted Devices Using Tang Server Key
 
 -   **[Create a Tang Key for Encrypted Device](../topics/cockpit-nbde_create_a_tang_key_for_the_encrypted_device.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-nbde_confirm_that_the_configuration_is_successful.md
+++ b/openela9/topics/cockpit-nbde_confirm_that_the_configuration_is_successful.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Confirm Tang Key Implementation on Encrypted Device
 
 **Parent topic:**[Unlock Encrypted Devices Using Tang Server Key](../topics/cockpit-nbde.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-nbde_create_a_tang_key_for_the_encrypted_device.md
+++ b/openela9/topics/cockpit-nbde_create_a_tang_key_for_the_encrypted_device.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Tang Key for Encrypted Device
 
 **Parent topic:**[Unlock Encrypted Devices Using Tang Server Key](../topics/cockpit-nbde.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-networ_view_firewall_log_files.md
+++ b/openela9/topics/cockpit-networ_view_firewall_log_files.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View Network Host Log Files
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network.md
+++ b/openela9/topics/cockpit-network.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Network Management Tasks
 
 -   **[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)**  
@@ -14,8 +18,4 @@
 
 -   **[View Network Host Log Files](../topics/cockpit-networ_view_firewall_log_files.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_access_zone_information.md
+++ b/openela9/topics/cockpit-network_access_zone_information.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Display Firewall Zone Properties
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_add_a_pre_defined_zone.md
+++ b/openela9/topics/cockpit-network_add_a_pre_defined_zone.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add a New Predefined Zone
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_configure_a_network_bond.md
+++ b/openela9/topics/cockpit-network_configure_a_network_bond.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network Bonding Properties
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_configure_a_network_team.md
+++ b/openela9/topics/cockpit-network_configure_a_network_team.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network Teaming Properties
 
 -   **[Teaming and Bonding Feature Comparison](../topics/cockpit-network_team_and_bond_feature_comparison.md)**  
 
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_configure_the_firewall.md
+++ b/openela9/topics/cockpit-network_configure_the_firewall.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Firewall Zoning Properties
 
 -   **[Change Host Firewall State](../topics/cockpit-network_enable_disable_firewalld_service.md)**  
@@ -12,8 +16,4 @@
 
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_control_access_to_interface.md
+++ b/openela9/topics/cockpit-network_control_access_to_interface.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Monitor or Change Interface Connections
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_enable_disable_firewalld_service.md
+++ b/openela9/topics/cockpit-network_enable_disable_firewalld_service.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Host Firewall State
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_remove_or_modify_zone.md
+++ b/openela9/topics/cockpit-network_remove_or_modify_zone.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove an Existing Predefined Zone
 
 **Parent topic:**[Manage Firewall Zoning Properties](../topics/cockpit-network_configure_the_firewall.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-network_team_and_bond_feature_comparison.md
+++ b/openela9/topics/cockpit-network_team_and_bond_feature_comparison.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Teaming and Bonding Feature Comparison
 
 **Parent topic:**[Configure Network Teaming Properties](../topics/cockpit-network_configure_a_network_team.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-nfsmounts.md
+++ b/openela9/topics/cockpit-nfsmounts.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage NFS Mounted Connections
 
 -   **[Add NFS Server Connections](../topics/cockpit-nfsmounts_connect_nfs_mounts.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-nfsmounts_connect_nfs_mounts.md
+++ b/openela9/topics/cockpit-nfsmounts_connect_nfs_mounts.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add NFS Server Connections
 
 **Parent topic:**[Manage NFS Mounted Connections](../topics/cockpit-nfsmounts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-nfsmounts_customize_mount_options.md
+++ b/openela9/topics/cockpit-nfsmounts_customize_mount_options.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change NFS Server Connections
 
 **Parent topic:**[Manage NFS Mounted Connections](../topics/cockpit-nfsmounts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-partition.md
+++ b/openela9/topics/cockpit-partition.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Disk Devices and Partitions
 
 -   **[Create Physical Disk Partitions](../topics/cockpit-partition_create_partitions.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-partition_considerations.md
+++ b/openela9/topics/cockpit-partition_considerations.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Storage Partitioning Considerations and Prerequisites
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-partition_create_partitions.md
+++ b/openela9/topics/cockpit-partition_create_partitions.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create Physical Disk Partitions
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-partition_display_partitions_that_are_formatted_with_file_systems.md
+++ b/openela9/topics/cockpit-partition_display_partitions_that_are_formatted_with_file_systems.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Change Drive Partition Properties
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-podman.md
+++ b/openela9/topics/cockpit-podman.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Management Tasks
 
 -   **[Install and Configure Cockpit-Podman](../topics/cockpit-podman_enable_podman_service.md)**  
@@ -8,8 +12,4 @@
 
 -   **[Podman Pod Management](../topics/podman_pod_management.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-podman_enable_podman_service.md
+++ b/openela9/topics/cockpit-podman_enable_podman_service.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Configure Cockpit-Podman
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-podman_managing_podman_containers.md
+++ b/openela9/topics/cockpit-podman_managing_podman_containers.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Container Management
 
 -   **[Create and Run Container](../topics/podman_container_mgmt.md)**  
@@ -16,8 +20,4 @@
 
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-podman_managing_podman_images.md
+++ b/openela9/topics/cockpit-podman_managing_podman_images.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Image Management
 
 -   **[Search and Download New Images](../topics/podman_image_download.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-raid.md
+++ b/openela9/topics/cockpit-raid.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Build and Manage Software RAID Devices
 
 -   **[Create and Configure a New Storage Array](../topics/cockpit-raid_create_raid_storage.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-raid_create_raid_storage.md
+++ b/openela9/topics/cockpit-raid_create_raid_storage.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create and Configure a New Storage Array
 
 **Parent topic:**[Build and Manage Software RAID Devices](../topics/cockpit-raid.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-raid_format_raid_storage.md
+++ b/openela9/topics/cockpit-raid_format_raid_storage.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Software RAID Levels
 
 **Parent topic:**[Build and Manage Software RAID Devices](../topics/cockpit-raid.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-selinux_manage.md
+++ b/openela9/topics/cockpit-selinux_manage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage SELinux Security Policy and Messages
 
 -   **[Change SELinux Policy Mode](../topics/cockpit-selinux_manage_policy_mode.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-selinux_manage_logs.md
+++ b/openela9/topics/cockpit-selinux_manage_logs.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage SELinux Alert Message
 
 **Parent topic:**[Manage SELinux Security Policy and Messages](../topics/cockpit-selinux_manage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-selinux_manage_policy_mode.md
+++ b/openela9/topics/cockpit-selinux_manage_policy_mode.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change SELinux Policy Mode
 
 **Parent topic:**[Manage SELinux Security Policy and Messages](../topics/cockpit-selinux_manage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-selinux_manage_script.md
+++ b/openela9/topics/cockpit-selinux_manage_script.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View SELinx Modifications and Copy Automation Script
 
 **Parent topic:**[Manage SELinux Security Policy and Messages](../topics/cockpit-selinux_manage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-services.md
+++ b/openela9/topics/cockpit-services.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Manage Services
 
 **Parent topic:**[System Monitoring Actions](../topics/cockpit-monitor.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-softwaremanage.md
+++ b/openela9/topics/cockpit-softwaremanage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Software Updates
 
 -   **[Apply Pending Software Updates Manually](../topics/cockpit-softwaremanage_manage_manual_software_updates.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-softwaremanage_manage_automatic_software_updates.md
+++ b/openela9/topics/cockpit-softwaremanage_manage_automatic_software_updates.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Schedule Automatic Software Updates
 
 **Parent topic:**[Software Updates](../topics/cockpit-softwaremanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-softwaremanage_manage_manual_software_updates.md
+++ b/openela9/topics/cockpit-softwaremanage_manage_manual_software_updates.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Apply Pending Software Updates Manually
 
 **Parent topic:**[Software Updates](../topics/cockpit-softwaremanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-storage_management.md
+++ b/openela9/topics/cockpit-storage_management.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Storage Management Tasks
 
 -   **[Storage Management Installation and Overview](../topics/cockpit_storage_information.md)**  
@@ -16,8 +20,4 @@
 
 -   **[Manage Connections to iSCSI Targets](../topics/cockpit_iscsi_targets.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-system_join_a_domain.md
+++ b/openela9/topics/cockpit-system_join_a_domain.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Join an Active Directory Domain
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-tuned.md
+++ b/openela9/topics/cockpit-tuned.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Tuned Performance Profile
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-usermanage.md
+++ b/openela9/topics/cockpit-usermanage.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # User Management Actions
 
 -   **[Create or Change User Accounts](../topics/cockpit-usermanage_create_a_user.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-usermanage_access_the_accounts_page.md
+++ b/openela9/topics/cockpit-usermanage_access_the_accounts_page.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Disconnect User Sessions or Remove User Accounts
 
 **Parent topic:**[User Management Actions](../topics/cockpit-usermanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-usermanage_create_a_user.md
+++ b/openela9/topics/cockpit-usermanage_create_a_user.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create or Change User Accounts
 
 **Parent topic:**[User Management Actions](../topics/cockpit-usermanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-volgroups.md
+++ b/openela9/topics/cockpit-volgroups.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change Volume Group Properties
 
 -   **[Add New Drive to a Volume Group](../topics/cockpit-volgroups_add_physical_drives_to_volume_groups.md)**  
@@ -12,8 +16,4 @@
 
 
 **Parent topic:**[Manage Logical Volumes With LVM](../topics/cockpit-lvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-volgroups_add_physical_drives_to_volume_groups.md
+++ b/openela9/topics/cockpit-volgroups_add_physical_drives_to_volume_groups.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add New Drive to a Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit-volgroups_remove_physical_drives_from_volume_groups.md
+++ b/openela9/topics/cockpit-volgroups_remove_physical_drives_from_volume_groups.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Physical Drive From Volume Group
 
 **Parent topic:**[Change Volume Group Properties](../topics/cockpit-volgroups.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit_disk_rates.md
+++ b/openela9/topics/cockpit_disk_rates.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View Disk Read and Write Rates
 
 **Parent topic:**[Manage Disk Devices and Partitions](../topics/cockpit-partition.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit_host_security_considerations.md
+++ b/openela9/topics/cockpit_host_security_considerations.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Security Considerations for Multiple Host Management
 
 **Parent topic:**[Management of Multiple Hosts](../topics/cockpit-manage_multiple_hosts.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit_iscsi_targets.md
+++ b/openela9/topics/cockpit_iscsi_targets.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Manage Connections to iSCSI Targets
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit_mgmt_cdrom_vm.md
+++ b/openela9/topics/cockpit_mgmt_cdrom_vm.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Insert or Remove Virtual CD-ROM on Virtual Machine
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit_overview.md
+++ b/openela9/topics/cockpit_overview.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Cockpit Web Console Overview
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/cockpit_storage_information.md
+++ b/openela9/topics/cockpit_storage_information.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Storage Management Installation and Overview
 
 **Parent topic:**[Storage Management Tasks](../topics/cockpit-storage_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/common_administration.md
+++ b/openela9/topics/common_administration.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Common Host Administration Tasks
 
 -   **[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)**  
@@ -10,8 +14,4 @@
 
 -   **[Software Updates](../topics/cockpit-softwaremanage.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/configure_network_bridging.md
+++ b/openela9/topics/configure_network_bridging.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network Bridging Properties
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/configure_networking_vlans.md
+++ b/openela9/topics/configure_networking_vlans.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configure Network VLAN Properties
 
 **Parent topic:**[Network Management Tasks](../topics/cockpit-network.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/create_clone_or_migrate_a_virtual_machine.md
+++ b/openela9/topics/create_clone_or_migrate_a_virtual_machine.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create, Import, Clone, or Migrate a VM Instance
 
 -   **[Create a VM Instance](../topics/cockpit-kvm_create_a_virtual_machine.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Virtual Machine \(VM\) Management Tasks](../topics/cockpit-kvm.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/diag_reports_evaluate_issues.md
+++ b/openela9/topics/diag_reports_evaluate_issues.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Evaluate System Problems Using Diagnostic Reports
 
 -   **[Generate Diagnostic Reports](../topics/diag_reports_generate.md)**  
@@ -6,8 +10,4 @@
 
 
 **Parent topic:**[Debugging Tools](../topics/manage_host_debugging_tools.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/diag_reports_generate.md
+++ b/openela9/topics/diag_reports_generate.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Generate Diagnostic Reports
 
 **Parent topic:**[Evaluate System Problems Using Diagnostic Reports](../topics/diag_reports_evaluate_issues.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/diag_reports_rm_dwnld.md
+++ b/openela9/topics/diag_reports_rm_dwnld.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Download or Remove Generated Reports
 
 **Parent topic:**[Evaluate System Problems Using Diagnostic Reports](../topics/diag_reports_evaluate_issues.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/disable_smt.md
+++ b/openela9/topics/disable_smt.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Disable SMT to Prevent CPU Security Issues
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/display_mode.md
+++ b/openela9/topics/display_mode.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Cockpit Background Theme
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/extend_cockpit.md
+++ b/openela9/topics/extend_cockpit.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Extend Cockpit's Functionality
 
 -   **[Install and Manage Add-on Applications](../topics/manage_add_on_applications.md)**  
 
 
 **Parent topic:**[Get Started: Cockpit Web Console](../topics/cockpit-install.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/firewall-ConfiguringaPacketFilteringFirewall.md
+++ b/openela9/topics/firewall-ConfiguringaPacketFilteringFirewall.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a Packet Filtering Firewall
 
 ## About Packet-Filtering Firewalls
@@ -31,8 +35,4 @@
 ### Using the firewall-cmd Command
 
 ### Using a Zone Configuration File
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/firewall-UsingthenftablesFramework.md
+++ b/openela9/topics/firewall-UsingthenftablesFramework.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using the nftables Framework
 
 ## Converting iptables to nftables
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/fsadmin-AboutFileSystemManagementinEnterpriseLinux.md
+++ b/openela9/topics/fsadmin-AboutFileSystemManagementinEnterpriseLinux.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About File System Management
 
 ## Supported File Systems
 
 ## Maximum File and File System Size Requirements
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/fsadmin-ManagingtheExtFileSystem.md
+++ b/openela9/topics/fsadmin-ManagingtheExtFileSystem.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing the Ext File System
 
 ## Converting a Non Root Ext File System to a Later Version
@@ -7,8 +11,4 @@
 ## Checking and Repairing an Ext File System
 
 ## Changing the Frequency of File System Checking for Ext File Systems
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/fsadmin-ManagingtheXFSFileSystem.md
+++ b/openela9/topics/fsadmin-ManagingtheXFSFileSystem.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing the XFS File System
 
 ## Installing XFS Packages
@@ -23,8 +27,4 @@
 ## Checking and Repairing an XFS File System
 
 ## Defragmenting an XFS File System
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/fsadmin-PerformingBasicFileSystemAdministration.md
+++ b/openela9/topics/fsadmin-PerformingBasicFileSystemAdministration.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Performing Basic File System Administration
 
 ## Building File Systems
@@ -43,8 +47,4 @@
 ### Reporting on Disk Quota Usage
 
 ### Maintaining the Accuracy of Disk Quota Reporting
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/manage_add_on_applications.md
+++ b/openela9/topics/manage_add_on_applications.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Manage Add-on Applications
 
 **Parent topic:**[Extend Cockpit's Functionality](../topics/extend_cockpit.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/manage_host_debugging_tools.md
+++ b/openela9/topics/manage_host_debugging_tools.md
@@ -1,11 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Debugging Tools
 
 -   **[Evaluate System Problems Using Diagnostic Reports](../topics/diag_reports_evaluate_issues.md)**  
 
 -   **[Capture Crash Dump Details Using Kdump](../topics/cockpit-kdump.md)**  
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/managing_system_certificates.md
+++ b/openela9/topics/managing_system_certificates.md
@@ -1,10 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing System Certificates
 
 ## Using the trust Command To Manage System Certificates
 
 ## Manually Updating Trusted Certificates
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/modify_crypto.md
+++ b/openela9/topics/modify_crypto.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change System-Wide Crypto Policy
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/nbde-AboutNetworkBoundDiskEncryption.md
+++ b/openela9/topics/nbde-AboutNetworkBoundDiskEncryption.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Network-Bound Disk Encryption
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/nbde-InstallandConfigureaTangServer.md
+++ b/openela9/topics/nbde-InstallandConfigureaTangServer.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Install and Configure a Tang Server
 
 ## Install the Tang Package and Enable the Tang Socket in Systemd
@@ -11,8 +15,4 @@
 ## Initialize Tang Signing Keys
 
 ## Rotate Tang Keys
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/nbde-PerformAutomatedEncryptionandDecryptionWithClevis.md
+++ b/openela9/topics/nbde-PerformAutomatedEncryptionandDecryptionWithClevis.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Perform Automated Encryption and Decryption With Clevis
 
 ## Install and Test Clevis
@@ -17,8 +21,4 @@
 ### Update Clevis for Tang Key Rotation
 
 ### Unbind Clevis from a LUKS Slot
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/network-AboutNetworkAddressTranslation.md
+++ b/openela9/topics/network-AboutNetworkAddressTranslation.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Network Address Translation
 
 Network Address Translation \(NAT\) is a process that assigns a public address to a computer or a group of computers inside a private network by using a different address scheme. The public IP address masquerades all the requests as though they're going to one server, rather than several servers. NAT is useful for limiting the number of public IP addresses that an organization must finance. NAT also provides extra security by hiding the details of internal networks.
@@ -21,8 +25,4 @@ sudo sysctl -w net.ipv4.ip_forward=0|1
 The new status is displayed when you run the command. To make the change persist across system reboots, copy the command output line and add it to the `/etc/sysctl.conf` file.
 
 You can also use the Firewall Configuration GUI \(`firewall-config`\) to configure masquerading and port forwarding.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/network-ConfiguringDHCPServices.md
+++ b/openela9/topics/network-ConfiguringDHCPServices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring DHCP Services
 
 The Dynamic Host Configuration Protocol \(DHCP\) enables client systems to obtain network configuration information from a DHCP server each time they connect to the network. The DHCP server is configured with a range of IP addresses and other network configuration parameters that clients need.
@@ -461,8 +465,4 @@ Ensure that you have the required administrative privileges and complete the fol
         sudo systemctl start dhcpd6
         ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/network-ConfiguringNetworkTime.md
+++ b/openela9/topics/network-ConfiguringNetworkTime.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring Network Time
 
 This chapter describes how to configure a system to use `chrony` as an implementation of the Network Time Protocol \(NTP\) feature, as a replacement for `ntp`. The chapter also describes the Precision Time Protocol \(PTP\) daemons that are used to set the system time.
@@ -439,8 +443,4 @@ These entries define the local system clock as the time reference.
 **Note:**
 
 Don't configure any added `server` lines in the file.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/network-ConfiguringtheNameService.md
+++ b/openela9/topics/network-ConfiguringtheNameService.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring the Name Service
 
 This chapter describes how to use Berkeley Internet Name Domain \(BIND\) to set up a Domain Name System \(DNS\) name server.
@@ -568,8 +572,4 @@ Received 72 bytes from 10.0.0.1#53 in 32 ms
 ```
 
 For more information, see the `host(1)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/network-ConfiguringtheSystemsNetwork.md
+++ b/openela9/topics/network-ConfiguringtheSystemsNetwork.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring the System's Network
 
 To enable the system to connect to the network, transmit and receive traffic with other systems, you would need to configure the system to have identifiable names, IP addresses, routes, and so on. Depending on the system's available resources, you can further optimize the network configuration to attain high availability and improved performance by implementing added network technologies such as network bonds and multipathing.
@@ -665,8 +669,4 @@ To convert the `NetworkManager` legacy `ifcfg` profile formats to the preferred 
     nmcli -f TYPE,FILENAME,NAME connection
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/network-OptimizingNetworkServersforHighAvailability.md
+++ b/openela9/topics/network-OptimizingNetworkServersforHighAvailability.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Optimizing Network Servers for High Availability
 
 For systems that provide network services to clients inside the network, network availability becomes a priority to ensure that the services are continuous and interruptions are prevented. With virtual local area networks \(VLANs\), you can also organize the network such that systems with similar functions are grouped together as though they belong to their own virtual networks. This feature improves network management and administration.
@@ -190,8 +194,4 @@ sudo ip link add link eth1 name eth1.5 type vlan id 5
 ```
 
 For more information, see the `ip(8)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/openssh-AboutOpenSSH.md
+++ b/openela9/topics/openssh-AboutOpenSSH.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About OpenSSH
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/openssh-ConfigureOpenSSHClient.md
+++ b/openela9/topics/openssh-ConfigureOpenSSHClient.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring the OpenSSH Client
 
 ## Installing the OpenSSH Client Packages
@@ -5,8 +9,4 @@
 ## Configuring OpenSSH Client Configuration Files
 
 ## Validating Configuration Permissions
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/openssh-ConfiguringOpenSSHServer.md
+++ b/openela9/topics/openssh-ConfiguringOpenSSHServer.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring OpenSSH Server
 
 ## Installing OpenSSH Server and Enabling sshd
@@ -16,8 +20,4 @@
 ### Restricting SSH Key Access to Specific Commands
 
 ## Good Practice Recommendations for Configuring OpenSSH Server
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/openssh-UsingOpenSSHClientUtilities.md
+++ b/openela9/topics/openssh-UsingOpenSSHClientUtilities.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using OpenSSH Client Utilities
 
 ## Connecting to Another System Using the ssh Command
@@ -15,8 +19,4 @@
 ## Using X11 Forwarding to Load Remote Graphical Applications
 
 ## Setting Up Port Forwarding Over SSH
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/openssh-WorkingwithSSHKeyPairs.md
+++ b/openela9/topics/openssh-WorkingwithSSHKeyPairs.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working with SSH Key Pairs
 
 ## How SSH Key Pairs Work
@@ -23,8 +27,4 @@
 [Working With OpenSSH Server Configuration Files](openssh-ConfiguringOpenSSHServer.md#)
 
 ## Good Practice Recommendations for Working with SSH Key Pairs
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/osmanage-ConfiguringSystemSettings.md
+++ b/openela9/topics/osmanage-ConfiguringSystemSettings.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring System Settings
 
 This chapter describes the files and virtual file systems that you can use to change the configuration settings for the system.
@@ -914,8 +918,4 @@ sudo systemctl enable --now watchdog
 The Watchdog service immediately starts and runs in the background.
 
 **Note:** The Watchdog service starts and runs immediately after a power reset.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/osmanage-ManagingKernelModules.md
+++ b/openela9/topics/osmanage-ManagingKernelModules.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Kernel Modules
 
 This chapter describes how to load, unload, and modify the behavior of kernel modules.
@@ -361,8 +365,4 @@ You can also use the `weak-modules` command with the `dry-run` option to test th
 weak-modules --remove-kernel --dry-run --verbose
 rm -rf kmod-kvdo
 ```
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/osmanage-ManagingResources.md
+++ b/openela9/topics/osmanage-ManagingResources.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Resources
 
 This chapter describes how to manage the use of resources in an Enterprise Linux system.
@@ -577,8 +581,4 @@ As a prerequisite to the following procedure, you must complete the preparations
 ## Using cgroups v2 to Manage Resources for Users
 
 The previous sample procedures describe how to manage applications' use of system resources. You can also manage resource use by directly implementing resource filters to users who log in to the system.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/osmanage-ManagingSystemDevices.md
+++ b/openela9/topics/osmanage-ManagingSystemDevices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing System Devices
 
 This chapter describes how the system uses device files and how the Udev device manager dynamically creates or removes device node files.
@@ -777,8 +781,4 @@ The following example illustrates how to implement a `udev` rules file that adds
 
 4.  \(Optional\) To undo the changes, remove `/etc/udev/rules.d/10-local.rules` and `/dev/my_disk`, then run `systemctl restart systemd-udevd` again.
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/osmanage-WorkingWithSystemServices.md
+++ b/openela9/topics/osmanage-WorkingWithSystemServices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing System Services With systemd
 
 The`systemd` daemon is the system initialization and service manager in Enterprise Linux. This chapter describes how to use `systemd`to manage system processes, services and `systemd` targets.
@@ -1005,8 +1009,4 @@ The following examples show how to use `systemd-run` to activate transient timer
     sudo systemd-run --on-calendar="17:00:00"
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/osmanage-WorkingWiththeGRUB2BootloaderandConfiguringBootServices.md
+++ b/openela9/topics/osmanage-WorkingWiththeGRUB2BootloaderandConfiguringBootServices.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Kernels and System Boot
 
 This chapter describes the Enterprise Linux boot process and how to configure and use the GRand Unified Bootloader \(GRUB\) version 2 and boot-related kernel parameters.
@@ -345,8 +349,4 @@ To modify the boot parameters for the GRUB 2 configuration so that these paramet
 For systems that boot with UEFI, the `grub.cfg` file is located in the `/boot/efi/EFI/redhat` directory because the boot configuration is stored on a dedicated FAT32-formatted partition.
 
 After the system has successfully booted, the `EFI` folder on that partition is mounted inside the `/boot/efi` directory on the root file system for Enterprise Linux.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_add_pod_container.md
+++ b/openela9/topics/podman_add_pod_container.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Add a Container to a Pod Group
 
 **Parent topic:**[Podman Pod Management](../topics/podman_pod_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_commit_changes.md
+++ b/openela9/topics/podman_commit_changes.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Commit Container Changes to Create New Image
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_container_checkpoint_restore.md
+++ b/openela9/topics/podman_container_checkpoint_restore.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Checkpoint and Restore a System Container
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_container_inspect_access_cli.md
+++ b/openela9/topics/podman_container_inspect_access_cli.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Inspect Container and Access Container Logs and CLI
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_container_mgmt.md
+++ b/openela9/topics/podman_container_mgmt.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create and Run Container
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_container_remove.md
+++ b/openela9/topics/podman_container_remove.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Container or Pod Group
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_container_rename_stop_start.md
+++ b/openela9/topics/podman_container_rename_stop_start.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Rename, Pause, Stop, or Restart Container
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_create_pod_group.md
+++ b/openela9/topics/podman_create_pod_group.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Create a Pod Group
 
 **Parent topic:**[Podman Pod Management](../topics/podman_pod_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_image_download.md
+++ b/openela9/topics/podman_image_download.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Search and Download New Images
 
 **Parent topic:**[Podman Image Management](../topics/cockpit-podman_managing_podman_images.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_inspect_pod.md
+++ b/openela9/topics/podman_inspect_pod.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Inspect and Change a Pod Group
 
 **Parent topic:**[Podman Pod Management](../topics/podman_pod_management.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_pod_management.md
+++ b/openela9/topics/podman_pod_management.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Podman Pod Management
 
 -   **[Create a Pod Group](../topics/podman_create_pod_group.md)**  
@@ -8,8 +12,4 @@
 
 
 **Parent topic:**[Podman Management Tasks](../topics/cockpit-podman.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_remove_image.md
+++ b/openela9/topics/podman_remove_image.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Remove Images
 
 **Parent topic:**[Podman Image Management](../topics/cockpit-podman_managing_podman_images.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_special_considerations.md
+++ b/openela9/topics/podman_special_considerations.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Special Considerations for Non Administrator Containers
 
 **Parent topic:**[Podman Container Management](../topics/cockpit-podman_managing_podman_containers.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/podman_view_image.md
+++ b/openela9/topics/podman_view_image.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # View and Inspect Available Images
 
 **Parent topic:**[Podman Image Management](../topics/cockpit-podman_managing_podman_images.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/reboot.md
+++ b/openela9/topics/reboot.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Restart or Power Off System
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/search_sort_view_accts.md
+++ b/openela9/topics/search_sort_view_accts.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Find and Manage Account Information
 
 **Parent topic:**[User Management Actions](../topics/cockpit-usermanage.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/securitypractice.md
+++ b/openela9/topics/securitypractice.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Security Management Actions
 
 -   **[Disable SMT to Prevent CPU Security Issues](../topics/disable_smt.md)**  
@@ -10,8 +14,4 @@
 
 
 **Parent topic:**[Common Host Administration Tasks](../topics/common_administration.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/selinux-AboutAdministeringSELinux.md
+++ b/openela9/topics/selinux-AboutAdministeringSELinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Administering SELinux in Enterprise Linux
 
 ## SELinux Package Descriptions
@@ -7,8 +11,4 @@
 ## Setting SELinux Modes
 
 ## Getting More Information
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/selinux-AdministeringSELinuxPolicies.md
+++ b/openela9/topics/selinux-AdministeringSELinuxPolicies.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Administering SELinux Policies
 
 ## Targeted Policy
@@ -7,8 +11,4 @@
 ## Setting or Switching SELinux Policies
 
 ## Customizing SELinux Policies
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/selinux-AdministeringSELinuxSecurityContext.md
+++ b/openela9/topics/selinux-AdministeringSELinuxSecurityContext.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Administering SELinux Security Context
 
 ## Displaying SELinux User Mapping
@@ -9,8 +13,4 @@
 ## Restoring the Default File Type
 
 ## Relabeling a File System
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/selinux-AdministeringSELinuxUsers.md
+++ b/openela9/topics/selinux-AdministeringSELinuxUsers.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Administering SELinux Users
 
 ## Understanding Confined SELinux Users
@@ -7,8 +11,4 @@
 ## Setting the Default User Mapping
 
 ## Configuring the Behavior of Application Execution for Users
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/selinux-TroubleshootingAccessDenialMessages.md
+++ b/openela9/topics/selinux-TroubleshootingAccessDenialMessages.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Troubleshooting Access-Denial Messages
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/selinux_multi_category_security_mcs.md
+++ b/openela9/topics/selinux_multi_category_security_mcs.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Extending SELinux Policies with Multi-Category Security
 
 ## MCS Requirements
@@ -9,8 +13,4 @@
 ## Applying MCS Categories to Files
 
 ## Enabling the mcstrans Service
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/set_host_name.md
+++ b/openela9/topics/set_host_name.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change System Hostname
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/set_session_time_out_for_web_console.md
+++ b/openela9/topics/set_session_time_out_for_web_console.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Set a Timeout for Inactive Sessions
 
 **Parent topic:**[Security Management Actions](../topics/securitypractice.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/set_system_time.md
+++ b/openela9/topics/set_system_time.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Change System Date and Time
 
 **Parent topic:**[General Host Configuration Actions](../topics/cockpit-config_host_tasks.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/sfw-mgmt-AboutDNFUtility.md
+++ b/openela9/topics/sfw-mgmt-AboutDNFUtility.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About the DNF Utility
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/sfw-mgmt-ConfigureaSystemtoUseEnterpriseLinuxYumServer.md
+++ b/openela9/topics/sfw-mgmt-ConfigureaSystemtoUseEnterpriseLinuxYumServer.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a System to Use Enterprise Linux Yum Server
 
 ## Configuring the Global DNF Configuration Settings
@@ -9,8 +13,4 @@
 ## Editing Yum Repository Configuration Files
 
 ## Using the DNF config-manager Plugin
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/sfw-mgmt-InstallSoftwareonEnterpriseLinux.md
+++ b/openela9/topics/sfw-mgmt-InstallSoftwareonEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Installing Software on Enterprise Linux
 
 ## Using DNF Groups
@@ -11,8 +15,4 @@
 ### How to Remove Installed Modules
 
 ### How to Switch Module Streams
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/sfw-mgmt-UpdateSoftwareonEnterpriseLinux.md
+++ b/openela9/topics/sfw-mgmt-UpdateSoftwareonEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Updating Software on Enterprise Linux
 
 ## Updating Software Automatically
@@ -5,8 +9,4 @@
 ## Disabling Updates for Particular Packages
 
 ## Using DNF to See Security Updates
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/sfw-mgmt-UseSoftwareDistributionMirrors.md
+++ b/openela9/topics/sfw-mgmt-UseSoftwareDistributionMirrors.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using Software Distribution Mirrors
 
 ## Prerequisites for the Local Distribution Mirror
@@ -11,8 +15,4 @@
 ### How to Mirror Repositories From an ISO
 
 ## How to Configure Client Access to the Local Mirror
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/sfw-mgmt-YumV3DNFComparison.md
+++ b/openela9/topics/sfw-mgmt-YumV3DNFComparison.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Comparing Yum Version 3 With DNF
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/shareadmin-AboutSharedFileSystemManagementinEnterpriseLinux.md
+++ b/openela9/topics/shareadmin-AboutSharedFileSystemManagementinEnterpriseLinux.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Shared File System Management
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/shareadmin-ManagingSambainEnterpriseLinux.md
+++ b/openela9/topics/shareadmin-ManagingSambainEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing Samba
 
 ## About Samba
@@ -29,8 +33,4 @@
 #### Using `smbclient` Commands
 
 #### Mounting a Samba Share with `cifs`
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/shareadmin-ManagingtheNetworkFileSysteminEnterpriseLinux.md
+++ b/openela9/topics/shareadmin-ManagingtheNetworkFileSysteminEnterpriseLinux.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Managing the Network File System
 
 ## About NFS
@@ -13,8 +17,4 @@
 ### Configuring an NFS Server by Using the exportfs Command
 
 ## Mounting an NFS File System
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/userauth-AboutSystemAuthentication.md
+++ b/openela9/topics/userauth-AboutSystemAuthentication.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About System Authentication
 
 Authentication is a way of implementing system security by verifying the identity of an entity, such as a user, to a system. A user logs in by providing a username and a password, and the OS authenticates the user's identity by comparing this information to data stored on the system. If the login credentials match and the user account is active, the user is authenticated and can successfully access the system.
@@ -79,8 +83,4 @@ To efficiently manage the variety of profiles, `authselect` stores different typ
 The `authselect` utility applies the specifications in the selected profile. However, `authselect` doesn't change the configuration files of the service on which the profile is based. If, for example, you use the `sssd` profile, you must configure SSSD for the service to function properly. Consult the proper documentation to configure the profile's service. You must also ensure that the service is started and enabled.
 
 For more details about the utility, see the `authselect(8)` manual page.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/userauth-GrantingsudoAccesstoUsers.md
+++ b/openela9/topics/userauth-GrantingsudoAccesstoUsers.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Granting sudo Access to Users
 
 In Enterprise Linux, only administrators can perform privileged tasks on the system.
@@ -239,8 +243,4 @@ Or, you can set group permissions directly in the `/etc/sudoers` file. For examp
     sudo usermod -aG wheel bob
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/userauth-UsingtheSystemSecurityServicesDaemon.md
+++ b/openela9/topics/userauth-UsingtheSystemSecurityServicesDaemon.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Using the System Security Services Daemon
 
 The System Security Services Daemon \(SSSD\) feature provides access on a client system to remote identity and authentication providers. The SSSD acts as an intermediary between local clients and any back-end provider that you configure.
@@ -221,8 +225,4 @@ The `include` flag specifies that PAM must also consult the PAM configuration fi
 Most authentication modules and PAM configuration files have their own manual pages. Relevant files are stored in the `/usr/share/doc/pam` directory.
 
 For more information, see the `pam(8)` manual page. In addition, each PAM module has its own manual page, for example `pam_unix(8)`, `postlogin(5)`, and `system-auth(5)`.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/userauth-WorkingWithSystemAuthenticationProfiles.md
+++ b/openela9/topics/userauth-WorkingWithSystemAuthenticationProfiles.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working With System Authentication Profiles
 
 The `authselect` command has various subcommands, arguments, and options to create, delete, switch to a different profile, and modify profile features. A user must have the appropriate privileges to be able to use this configuration tool.
@@ -305,8 +309,4 @@ If you do not want to use the profiles included in Enterprise Linux or those pro
     sudo authselect current
     ```
 
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/userauth-WorkingWithUserandGroupAccounts.md
+++ b/openela9/topics/userauth-WorkingWithUserandGroupAccounts.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Working With User and Group Accounts
 
 By default, a new installation of Enterprise Linux uses local user and group accounts for authentication, permissions handling, and access to resources. When working with local accounts for users and groups, you use three main commands: `useradd`, `groupadd`, and `usermod`. Through these commands and their different options, you can add or delete users and groups, as well as modify user or group settings.
@@ -262,8 +266,4 @@ sudo useradd -D -f 30
 A value of -1 specifies that user accounts aren't locked because of inactivity.
 
 For more information, see the `useradd(8)` and `usermod(8)` manual pages.
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/view_system.md
+++ b/openela9/topics/view_system.md
@@ -1,8 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Health, Usage, and System Details
 
 **Parent topic:**[System Monitoring Actions](../topics/cockpit-monitor.md)
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/vpn-AboutVirtualPrivateNetworks.md
+++ b/openela9/topics/vpn-AboutVirtualPrivateNetworks.md
@@ -1,6 +1,6 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # About Virtual Private Networks
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/vpn-ConfiguringaVPNbyUsingLibreswan.md
+++ b/openela9/topics/vpn-ConfiguringaVPNbyUsingLibreswan.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a VPN by Using Libreswan
 
 ## Installing Libreswan
@@ -9,8 +13,4 @@
 ### Creating a Site to Site Connection
 
 ## Verifying the Status of VPN Services
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 

--- a/openela9/topics/vpn-ConfiguringaVPNbyUsingWireGuard.md
+++ b/openela9/topics/vpn-ConfiguringaVPNbyUsingWireGuard.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2023,2024 Oracle and/or its affiliates.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 # Configuring a VPN by Using WireGuard
 
 ## Installing WireGuard
@@ -9,8 +13,4 @@
 ## Testing the WireGuard Tunnel
 
 ## Shutting Down the WireGuard Tunnel
-
----
-
-Copyright © 2023, Oracle and/or its affiliates.
 


### PR DESCRIPTION
This update changes the Oracle Copyright notices to move them into SPDX comments in all of the markdown files that were originally contributed by Oracle.s